### PR TITLE
Require Indico 2.0

### DIFF
--- a/audiovisual/setup.py
+++ b/audiovisual/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'audiovisual = indico_audiovisual.plugin:AVRequestsPlugin'},

--- a/burotel/setup.py
+++ b/burotel/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=('indico_burotel',),
     zip_safe=False,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'burotel = indico_burotel:BurotelPlugin'}

--- a/conversion/setup.py
+++ b/conversion/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'conversion = indico_conversion.plugin:ConversionPlugin'},

--- a/cronjobs_cern/setup.py
+++ b/cronjobs_cern/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'cronjobs_cern = indico_cronjobs_cern.plugin:CERNCronjobsPlugin'}

--- a/custom_themes/setup.py
+++ b/custom_themes/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'themes_cern = indico_custom_themes.plugins:CERNThemesPlugin',

--- a/foundationsync/setup.py
+++ b/foundationsync/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=('indico_foundationsync',),
     zip_safe=False,
     install_requires=[
-        'indico>=2.0a1',
+        'indico>=2.0',
         'cx_Oracle',
     ],
     entry_points={

--- a/livesync_cern/setup.py
+++ b/livesync_cern/setup.py
@@ -21,8 +21,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1',
-        'indico-plugin-livesync>=1.0a1'
+        'indico>=2.0',
+        'indico-plugin-livesync>=1.0'
     ],
     entry_points={
         'indico.plugins': {'livesync_cern = indico_livesync_cern.plugin:CERNLiveSyncPlugin'}

--- a/outlook/setup.py
+++ b/outlook/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'outlook = indico_outlook.plugin:OutlookPlugin'},

--- a/payment_cern/setup.py
+++ b/payment_cern/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1'
+        'indico>=2.0'
     ],
     entry_points={
         'indico.plugins': {'payment_cern = indico_payment_cern.plugin:CERNPaymentPlugin'},

--- a/ravem/setup.py
+++ b/ravem/setup.py
@@ -21,8 +21,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1',
-        'indico-plugin-vc-vidyo>=1.0a1',
+        'indico>=2.0',
+        'indico-plugin-vc-vidyo>=1.0',
     ],
     entry_points={
         'indico.plugins': {'ravem = indico_ravem.plugin:RavemPlugin'},

--- a/search_cern/setup.py
+++ b/search_cern/setup.py
@@ -21,8 +21,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=[
-        'indico>=2.0a1',
-        'indico-plugin-search>=1.0a1'
+        'indico>=2.0',
+        'indico-plugin-search>=1.0'
     ],
     entry_points={
         'indico.plugins': {'search_cern = indico_search_cern.plugin:CERNSearchPlugin'},


### PR DESCRIPTION
Kind of pointless without a version bump, but it's cleaner this way since the prerelease versions are a thing of the past 👴 