### PR TITLE
CERNAccess: require at least one reg. form

### DIFF
--- a/cern_access/indico_cern_access/definition.py
+++ b/cern_access/indico_cern_access/definition.py
@@ -8,8 +8,9 @@
 from __future__ import unicode_literals
 
 import dateutil.parser
-from flask import session
+from flask import flash, session
 from flask_pluginengine import plugin_context
+from markupsafe import Markup
 
 from indico.modules.events.requests import RequestDefinitionBase
 from indico.modules.events.requests.models.requests import RequestState
@@ -71,6 +72,13 @@ class CERNAccessRequestDefinition(RequestDefinitionBase):
         req.state = RequestState.accepted
         if times_changed:
             handle_event_time_update(req.event)
+
+        link = "https://indico-user-docs.web.cern.ch/indico-user-docs/cern/cern_access/#granting-access-to-participants"
+        message = _('Please note that even though your request has been accepted, you still have to '
+                    'request badges for each one of your participants. {link}More details here.{endlink}').format(
+                        link='<a href="{}">'.format(link),
+                        endlink='</a>')
+        flash(Markup(message), 'warning')
 
     @classmethod
     def withdraw(cls, req, notify_event_managers=False):

--- a/cern_access/indico_cern_access/forms.py
+++ b/cern_access/indico_cern_access/forms.py
@@ -27,6 +27,7 @@ from indico_cern_access import _
 
 class CERNAccessForm(RequestFormBase):
     regforms = IndicoSelectMultipleCheckboxField(_('Registration forms'),
+                                                 [DataRequired(_('At least one registration form has to be selected'))],
                                                  widget=JinjaWidget('regform_list_widget.html', 'cern_access'))
     start_dt_override = IndicoDateTimeField(_('Start date override'), [Optional()],
                                             description=_("If set, CERN access will be granted starting at the "

--- a/cern_access/indico_cern_access/templates/cern_access_status.html
+++ b/cern_access/indico_cern_access/templates/cern_access_status.html
@@ -21,7 +21,7 @@
 {% elif header %}
     <th class="i-table id-column sorter-false">
         <script>
-            $('#registration-list').on('click', '.js-copy-cern-access-code', function() {
+            $('#registration-list .js-list-table-wrapper').on('click', '.js-copy-cern-access-code', function() {
                 var $this = $(this);
                 var msg = $this.data('cern-access-message');
                 var code = '<code style="font-weight: bold; font-size: 2em;">{0}</code>'.format($this.data('cern-access-code'));

--- a/cern_access/indico_cern_access/util.py
+++ b/cern_access/indico_cern_access/util.py
@@ -149,7 +149,8 @@ def update_access_request(req):
     for regform_id in existing_forms_ids - requested_forms_ids:
         regform = event_regforms[regform_id]
         registrations = get_requested_registrations(event, regform=regform)
-        send_adams_delete_request(registrations)
+        if registrations:
+            send_adams_delete_request(registrations)
         regform.cern_access_request.request_state = CERNAccessRequestState.withdrawn
         remove_access_template(regform)
         withdraw_access_requests(registrations)
@@ -186,7 +187,8 @@ def withdraw_event_access_request(req):
     """Withdraw all CERN access requests of an event."""
     requested_forms = get_requested_forms(req.event)
     requested_registrations = get_requested_registrations(req.event)
-    send_adams_delete_request(requested_registrations)
+    if requested_registrations:
+        send_adams_delete_request(requested_registrations)
     for regform in requested_forms:
         regform.cern_access_request.request_state = CERNAccessRequestState.withdrawn
         remove_access_template(regform)
@@ -291,6 +293,8 @@ def send_form_link(event, registrations):
 
 
 def revoke_access(registrations):
+    if not registrations:
+        return
     send_adams_delete_request(registrations)
     requested_registrations = [reg for reg in registrations if
                                reg.cern_access_request and not

--- a/cern_access/setup.py
+++ b/cern_access/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='indico-plugin-cern-access',
-    version='1.0b7',
+    version='1.0',
     url='https://github.com/indico/indico-plugins-cern',
     license='MIT',
     author='Indico Team',


### PR DESCRIPTION
Requests with no selected registration forms are confusing.
Also added a message box pointing to the docs once a request is sent/accepted.