### PR TITLE
CERN access improvements

### DIFF
--- a/cern_access/indico_cern_access/definition.py
+++ b/cern_access/indico_cern_access/definition.py
@@ -17,7 +17,7 @@ from indico.modules.events.requests.models.requests import RequestState
 from indico.web.forms.base import FormDefaults
 
 from indico_cern_access import _
-from indico_cern_access.forms import CERNAccessForm, RegformDataMode
+from indico_cern_access.forms import CERNAccessForm
 from indico_cern_access.util import (check_access, get_access_dates, handle_event_time_update, is_authorized_user,
                                      is_category_blacklisted, is_event_too_early, update_access_request,
                                      withdraw_event_access_request)
@@ -27,14 +27,15 @@ class CERNAccessRequestDefinition(RequestDefinitionBase):
     name = 'cern-access'
     title = _('CERN Visitor Badges')
     form = CERNAccessForm
-    form_defaults = {'regform_data_mode': RegformDataMode.during_registration}
+    form_defaults = {'during_registration': True,
+                     'during_registration_preselected': False,
+                     'during_registration_required': False}
 
     @classmethod
     def create_form(cls, event, existing_request=None):
         default_data = cls.form_defaults
         if existing_request:
             default_data = dict(existing_request.data)
-            default_data.setdefault('regform_data_mode', RegformDataMode.after_registration)
             if default_data['start_dt_override']:
                 default_data['start_dt_override'] = dateutil.parser.parse(default_data['start_dt_override'])
             if default_data['end_dt_override']:

--- a/cern_access/indico_cern_access/forms.py
+++ b/cern_access/indico_cern_access/forms.py
@@ -21,14 +21,12 @@ from indico.modules.events.requests import RequestFormBase
 from indico.util.countries import get_countries
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import (IndicoDateField, IndicoDateTimeField, IndicoEnumSelectField,
-                                     IndicoSelectMultipleCheckboxField)
+from indico.web.forms.fields import IndicoDateField, IndicoDateTimeField, IndicoSelectMultipleCheckboxField
 from indico.web.forms.util import inject_validators
-from indico.web.forms.validators import LinkedDateTime, UsedIf
+from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
 from indico.web.forms.widgets import JinjaWidget, SwitchWidget
 
 from indico_cern_access import _
-from indico_cern_access.util import RegformDataMode
 
 
 class GrantAccessEmailForm(EmailRegistrantsForm):
@@ -57,14 +55,22 @@ class CERNAccessForm(RequestFormBase):
     regforms = IndicoSelectMultipleCheckboxField(_('Registration forms'),
                                                  [DataRequired(_('At least one registration form has to be selected'))],
                                                  widget=JinjaWidget('regform_list_widget.html', 'cern_access'))
-    regform_data_mode = IndicoEnumSelectField(_('Show during user registration'),
-                                              enum=RegformDataMode, keep_enum=False,
-                                              description=_("When enabled, users can request site access while "
-                                                            "registering and provide their additional personal data "
-                                                            "in the registration form. When set to required, the user "
-                                                            "cannot register without providing this data. In any case, "
-                                                            "site access is only granted after a manager explicitly "
-                                                            "enables it for the registrations."))
+    during_registration = BooleanField(_('Show during user registration'), widget=SwitchWidget(),
+                                       description=_("When enabled, users can request site access while registering "
+                                                     "and provide their additional personal data in the registration "
+                                                     "form. In any case, site access is only granted after a manager "
+                                                     "explicitly enables it for the registrants."))
+    during_registration_preselected = BooleanField(_('Preselect during user registration'),
+                                                   [HiddenUnless('during_registration')], widget=SwitchWidget(),
+                                                   description=_("Preselect the option to request site access during "
+                                                                 "registration. Recommended if most registrants will "
+                                                                 "need it."))
+    during_registration_required = BooleanField(_('Require during user registration'),
+                                                [HiddenUnless('during_registration_preselected')],
+                                                widget=SwitchWidget(),
+                                                description=_("Require all users to provide data for site access. "
+                                                              "Registration without entering the data will not be "
+                                                              "possible."))
     start_dt_override = IndicoDateTimeField(_('Start date override'), [Optional()],
                                             description=_("If set, CERN access will be granted starting at the "
                                                           "specified date instead of the event's start date"))

--- a/cern_access/indico_cern_access/plugin.py
+++ b/cern_access/indico_cern_access/plugin.py
@@ -182,7 +182,8 @@ class CERNAccessPlugin(IndicoPlugin):
     def _registration_deleted(self, registration, **kwargs):
         """Withdraw CERN access request for deleted registrations."""
         if registration.cern_access_request and not self._is_past_event(registration.event):
-            send_adams_delete_request([registration])
+            if registration.cern_access_request.is_active:
+                send_adams_delete_request([registration])
             registration.cern_access_request.request_state = CERNAccessRequestState.withdrawn
 
     def _registration_created(self, registration, management, **kwargs):

--- a/cern_access/indico_cern_access/templates/cern_access_status.html
+++ b/cern_access/indico_cern_access/templates/cern_access_status.html
@@ -1,6 +1,16 @@
 {% if registration %}
     {% set access_requested = registration.cern_access_request and registration.cern_access_request.is_active %}
-    <td class="i-table id-column" id="cern-access-status-{{ registration.id }}">
+    {% if access_requested and not registration.cern_access_request.has_identity_info %}
+        {% set sort_text = '2-data-missing' %}
+    {% elif not access_requested and registration.cern_access_request.has_identity_info %}
+        {% set sort_text = '0-has-data' %}
+    {% elif access_requested and registration.cern_access_request.is_active %}
+        {% set sort_text = '1-has-access' %}
+    {% else %}
+        {% set sort_text = '3-no-access' %}
+    {% endif %}
+
+    <td class="i-table id-column" id="cern-access-status-{{ registration.id }}" data-text="{{ sort_text }}">
         {% if access_requested and not registration.cern_access_request.has_identity_info %}
             <a class="icon-user-check semantic-text warning"
                title="{% trans %}Needs additional data. Click to enter it on behalf of the user{% endtrans %}"
@@ -22,7 +32,8 @@
         {% endif %}
     </td>
 {% elif header %}
-    <th class="i-table id-column sorter-false">
+    <th class="i-table id-column">
+        <i class="icon-id-badge" title="{% trans %}CERN site access{% endtrans %}"></i>
         <script>
             $('#registration-list .js-list-table-wrapper').on('click', '.js-copy-cern-access-code', function() {
                 var $this = $(this);

--- a/cern_access/indico_cern_access/templates/event_request_details.html
+++ b/cern_access/indico_cern_access/templates/event_request_details.html
@@ -48,3 +48,18 @@
         {{ super() }}
     {% endif %}
 {% endblock %}
+
+{% block scripts %}
+    <script>
+        $('#request-during_registration').on('change', function() {
+            if (!this.checked) {
+                $('#request-during_registration_preselected').prop('checked', false).trigger('change');
+            }
+        });
+        $('#request-during_registration_preselected').on('change', function() {
+            if (!this.checked) {
+                $('#request-during_registration_required').prop('checked', false).trigger('change');
+            }
+        });
+    </script>
+{% endblock %}

--- a/cern_access/indico_cern_access/util.py
+++ b/cern_access/indico_cern_access/util.py
@@ -37,10 +37,15 @@ from indico_cern_access.models.access_requests import CERNAccessRequest, CERNAcc
 
 
 class RegformDataMode(RichIntEnum):
-    __titles__ = [_('No'), _('Yes'), _('Yes (required)')]
+    __titles__ = [_('No'), _('Yes'), _('Yes (required)'), _('Yes (default)')]
     after_registration = 0
     during_registration = 1
     during_registration_required = 2
+    during_registration_default = 3
+
+    @classmethod
+    def is_during(cls, value):
+        return value in (cls.during_registration, cls.during_registration_required, cls.during_registration_default)
 
 
 def get_last_request(event):

--- a/cern_access/indico_cern_access/util.py
+++ b/cern_access/indico_cern_access/util.py
@@ -33,19 +33,7 @@ from indico.web.flask.templating import get_template_module
 
 from indico_cern_access import _
 from indico_cern_access.models.access_request_regforms import CERNAccessRequestRegForm
-from indico_cern_access.models.access_requests import CERNAccessRequest, CERNAccessRequestState, RichIntEnum
-
-
-class RegformDataMode(RichIntEnum):
-    __titles__ = [_('No'), _('Yes'), _('Yes (required)'), _('Yes (default)')]
-    after_registration = 0
-    during_registration = 1
-    during_registration_required = 2
-    during_registration_default = 3
-
-    @classmethod
-    def is_during(cls, value):
-        return value in (cls.during_registration, cls.during_registration_required, cls.during_registration_default)
+from indico_cern_access.models.access_requests import CERNAccessRequest, CERNAccessRequestState
 
 
 def get_last_request(event):

--- a/cern_access/setup.py
+++ b/cern_access/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='indico-plugin-cern-access',
-    version='2.0.2',
+    version='2.0.3',
     url='https://github.com/indico/indico-plugins-cern',
     license='MIT',
     author='Indico Team',


### PR DESCRIPTION
- allow sorting by state
- add icon in header (to make it clearer there's something to click)
- add option to request access by default (without requiring it)

```python
from sqlalchemy.orm.attributes import flag_modified
for req in Request.query.filter_by(type='cern-access'):
    if 'regform_data_mode' not in req.data:
        req.data['during_registration'] = False
        req.data['during_registration_preselected'] = False
        req.data['during_registration_required'] = False
    else:
        mode = req.data.pop('regform_data_mode')
        req.data['during_registration'] = mode in (1, 2, 3)
        req.data['during_registration_preselected'] = mode in (2, 3)
        req.data['during_registration_required'] = mode == 2
    flag_modified(req, 'data')
```