### PR TITLE
Audiovisual: set reply address for notifications

### DIFF
--- a/audiovisual/indico_audiovisual/definition.py
+++ b/audiovisual/indico_audiovisual/definition.py
@@ -52,6 +52,11 @@ class AVRequest(RequestDefinitionBase):
         return set(current_plugin.settings.get('notification_emails'))
 
     @classmethod
+    def get_notification_reply_email(cls):
+        return (current_plugin.settings.get('notification_reply_email') or
+                super(AVRequest, cls).get_notification_reply_email())
+
+    @classmethod
     def get_notification_template(cls, name, **context):
         context['SubContribution'] = SubContribution
         return super(AVRequest, cls).get_notification_template(name, **context)

--- a/audiovisual/indico_audiovisual/plugin.py
+++ b/audiovisual/indico_audiovisual/plugin.py
@@ -11,6 +11,7 @@ from flask import g, request, session
 from flask_pluginengine import render_plugin_template, url_for_plugin
 from sqlalchemy.orm.attributes import flag_modified
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
+from wtforms.fields.core import StringField
 from wtforms.fields.html5 import URLField
 from wtforms.validators import DataRequired, ValidationError
 
@@ -25,6 +26,7 @@ from indico.modules.rb.models.room_features import RoomFeature
 from indico.modules.users import User
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import EmailListField, MultipleItemsField, PrincipalListField
+from indico.web.forms.validators import IndicoEmail
 from indico.web.http_api import HTTPAPIHook
 from indico.web.menu import TopMenuItem
 
@@ -45,6 +47,10 @@ class PluginSettingsForm(IndicoForm):
     notification_emails = EmailListField(_('Notification email addresses'),
                                          description=_('Notifications about recording/webcast requests are sent to '
                                                        'these email addresses (one per line).'))
+    notification_reply_email = StringField(_('E-mail notification "reply" address'),
+                                           [IndicoEmail()],
+                                           description=_('Notifications that are sent to event managers will use '
+                                                         'this address in their "Reply-To:" fields.'))
     webcast_audiences = MultipleItemsField(_('Webcast Audiences'),
                                            fields=[{'id': 'audience', 'caption': _('Audience'), 'required': True}],
                                            unique_field='audience',
@@ -79,8 +85,9 @@ class AVRequestsPlugin(IndicoPlugin):
     configurable = True
     settings_form = PluginSettingsForm
     default_settings = {'webcast_audiences': [],
+                        'notification_reply_email': '',
                         'notification_emails': [],
-                        'webcast_ping_url': None,
+                        'webcast_ping_url': '',
                         'webcast_url': '',
                         'agreement_paper_url': None,
                         'recording_cds_url': 'https://cds.cern.ch/record/{cds_id}',


### PR DESCRIPTION
This PR utilizes the changes made in https://github.com/indico/indico/pull/3938 to add a config option for the "Reply To:" address of notifications sent by the audiovisual plugin.