### PR TITLE
Council Theme - improvements

### DIFF
--- a/themes_cern/indico_themes_cern/templates/council.html
+++ b/themes_cern/indico_themes_cern/templates/council.html
@@ -2,3 +2,28 @@
 
 {# Hide location #}
 {% set show_siblings_location = false %}
+
+{# Customize "day header" to add time information #}
+{% block day_header %}
+    <div class="day-header" style="width: 100%;">
+        <div class="day-title" data-anchor="{{ anchor }}">
+            {% trans start_date=item.start_dt|format_date(format='EEEE, d MMMM', timezone=timezone),
+                     start_time=item.start_dt | format_time(format='short') -%}
+                {{ start_date }} at {{ start_time }}
+            {%- endtrans %}
+        </div>
+        {% if days %}
+            <a class="js-go-to-day icon-calendar arrow js-dropdown" data-toggle="dropdown"></a>
+
+            <ul class="dropdown days-dropdown">
+                {% for day, _ in days %}
+                    <li>
+                        <a href="#day-{{ day.isoformat() }}">
+                            {{ day | format_date(format='EEE, d MMM', timezone=timezone) }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/themes_cern/indico_themes_cern/themes-cern.yaml
+++ b/themes_cern/indico_themes_cern/themes-cern.yaml
@@ -158,6 +158,7 @@ definitions:
       hide_duration: true
       hide_session_block_time: true
       number_contributions: true
+      hide_end_time: true
 
   # Meetings - CERN Administrative
   administrative: &administrative

--- a/themes_cern/indico_themes_cern/themes/council.scss
+++ b/themes_cern/indico_themes_cern/themes/council.scss
@@ -11,10 +11,30 @@ div.event-header {
     background-size: cover;
 }
 
-.timetable-item-body .timetable-item-header .timetable-title.top-level {
-    font-size: 1.5em;
-    font-weight: normal;
-    text-align: center;
+// Make top level items bigger and non-bold
+.timetable-item-body .timetable-item-header {
+    .timetable-title.top-level, .timetable-title.break {
+        font-size: 1.5em;
+        font-weight: normal;
+        text-align: center;
+    }
+}
+
+// This just makes nested breaks look like top-level ones.
+.timetable-time.break.nested {
+    border: 0;
+    margin-right: 0;
+
+    .start-time {
+        background-color: $tt-primary-color;
+        font-weight: bold;
+        box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.1);
+        margin-left: calc(-1em - 10px);
+        padding: 0 10px 0 20px;
+        position: relative;
+
+        @include ribbon($tt-secondary-color);
+    }
 }
 
 .timetable-item .timetable-time.nested .start-time {


### PR DESCRIPTION
Some improvements in the "Council" theme:

 * Show start time in "day header";
 * Hide end time in entries;
 * Make breaks look the same regardless of being nested or not;

I added a few core commits [in here](https://github.com/indico/indico/pull/3938/commits), to avoid opening yet another PR.