### PR TITLE
CERNAccess: make warning text less ambiguous

### DIFF
--- a/cern_access/indico_cern_access/templates/event_request_details.html
+++ b/cern_access/indico_cern_access/templates/event_request_details.html
@@ -28,12 +28,12 @@
             <div class="message-box-content">
                 <span class="icon"></span>
                 <div class="message-text">
-                    {% trans -%}
-                        By sending this request you are giving event participants access to the CERN site.
-                        Please note that after the request is accepted, you will need to grant the access to every participant
-                        manually on the registration list page. By default the tickets will be sent to them automatically afterwards.<br>
-                        <strong>Before granting access to any user please make sure that the event is in its final form.</strong>
-                        If you change the:
+                    {% trans link='<a href="https://indico-user-docs.web.cern.ch/indico-user-docs/cern/cern_access/#granting-access-to-participants">'|safe, endlink='</a>'|safe-%}
+                        After filling in this form, {{link}}<strong>you will need to grant the access
+                        to every participant manually</strong>{{endlink}} on the registration list page. By default the
+                        tickets will be sent to them automatically afterwards.<br>
+                        <strong>Before granting access to any user please make sure that the event is in its final
+                        form.</strong> If you change the:
                         <ul>
                             <li><strong>starting or ending time of the event</strong></li>
                             <li><strong>title of the event</strong></li>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2699/61058522-b9257480-a3f7-11e9-8bc4-0e7482819fab.png)

The link leads [here](https://indico-user-docs.web.cern.ch/indico-user-docs/cern/cern_access/#granting-access-to-participants).