### PR TITLE
Burotel: Use react/sui from webpack externals

### DIFF
--- a/burotel/indico_burotel/controllers.py
+++ b/burotel/indico_burotel/controllers.py
@@ -31,7 +31,7 @@ def get_month_dates(start_month, end_month):
 class WPBurotelBase(WPNewBase):
     template_prefix = 'rb/'
     title = _('Burotel')
-    bundles = ('common.js',)
+    bundles = ('common.js', 'common.css', 'react.js', 'react.css', 'semantic-ui.js', 'semantic-ui.css')
 
 
 class RHLanding(RHRoomBookingBase):

--- a/burotel/indico_burotel/plugin.py
+++ b/burotel/indico_burotel/plugin.py
@@ -56,10 +56,6 @@ class BurotelPlugin(IndicoPlugin):
         self.connect(signals.plugin.schema_post_dump, self._inject_long_term_attribute, sender=RoomSchema)
         self.connect(signals.plugin.schema_pre_load, self._inject_reason, sender=CreateBookingSchema)
         self.connect(signals.plugin.schema_pre_load, self._inject_time)
-        self.inject_bundle('react.js', WPBurotelBase)
-        self.inject_bundle('react.css', WPBurotelBase)
-        self.inject_bundle('semantic-ui.js', WPBurotelBase)
-        self.inject_bundle('semantic-ui.css', WPBurotelBase)
         self.inject_bundle('burotel.js', WPBurotelBase)
         self.inject_bundle('burotel.css', WPBurotelBase)
 


### PR DESCRIPTION
related to indico/indico#4605

With the changes in there, the build in the plugin no longer produces separate react/sui bundles so we need to keep including the core ones.