### PR TITLE
Themes CERN: Restore overflow in the timetable item wrapper

### DIFF
--- a/themes_cern/indico_themes_cern/themes/council.scss
+++ b/themes_cern/indico_themes_cern/themes/council.scss
@@ -11,6 +11,11 @@ div.event-header {
   background-size: cover;
 }
 
+.timetable-block > .timetable-item-body:first-of-type {
+  // Restores left overflow to cope with the margin-left applied below
+  overflow: visible;
+}
+
 // Make top level items bigger and non-bold
 .timetable-item-body .timetable-item-header {
   .timetable-title.top-level,


### PR DESCRIPTION
Allows margin overflows to fix the timetable time elements.

![imagem](https://user-images.githubusercontent.com/12183954/119837417-780ab080-befa-11eb-89e5-359350d5d113.png)
