### PR TITLE
Fix DeprecationWarning breaking tests

### DIFF
--- a/burotel/pytest.ini
+++ b/burotel/pytest.ini
@@ -13,5 +13,7 @@ filterwarnings =
     ignore:defusedxml\.lxml is no longer supported and will be removed in a future release\.:DeprecationWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/cern_access/pytest.ini
+++ b/cern_access/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/payment_cern/pytest.ini
+++ b/payment_cern/pytest.ini
@@ -12,5 +12,7 @@ filterwarnings =
     ignore::UserWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server

--- a/ravem/pytest.ini
+++ b/ravem/pytest.ini
@@ -13,5 +13,7 @@ filterwarnings =
     ignore:defusedxml\.lxml is no longer supported and will be removed in a future release\.:DeprecationWarning
     # port_for via pytest-redis
     ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+    # celery
+    ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
 ; use redis-server from $PATH
 redis_exec = redis-server


### PR DESCRIPTION
Celery is using an invalid legacy version specifier (celery/celery#7074)