### PR TITLE
Make sender email configurable

### DIFF
--- a/cronjobs_cern/indico_cronjobs_cern/plugin.py
+++ b/cronjobs_cern/indico_cronjobs_cern/plugin.py
@@ -5,6 +5,9 @@
 # them and/or modify them under the terms of the MIT License; see
 # the LICENSE file for more details.
 
+from wtforms.fields import EmailField
+from wtforms.validators import DataRequired, Email
+
 from indico.core.plugins import IndicoPlugin
 from indico.util.string import natural_sort_key
 from indico.web.forms.base import IndicoForm
@@ -17,9 +20,11 @@ def _order_func(object_list):
 
 class SettingsForm(IndicoForm):
     _fieldsets = [
+        ('General settings', ['sender_email']),
         ('Seminar emails', ['seminar_categories', 'seminar_recipients'])
     ]
 
+    sender_email = EmailField('Sender', [DataRequired(), Email()])
     seminar_categories = MultipleItemsField('Seminar categories',
                                             fields=[{'id': 'id', 'caption': 'Category ID', 'required': True}])
     seminar_recipients = EmailListField('Recipients')
@@ -33,6 +38,7 @@ class CERNCronjobsPlugin(IndicoPlugin):
     configurable = True
     settings_form = SettingsForm
     default_settings = {
+        'sender_email': 'noreply-indico-team@cern.ch',
         'seminar_categories': set(),
         'seminar_recipients': set()
     }

--- a/cronjobs_cern/indico_cronjobs_cern/tasks.py
+++ b/cronjobs_cern/indico_cronjobs_cern/tasks.py
@@ -45,7 +45,8 @@ def _get_category_events_query(start_dt, end_dt, category_ids):
 
 
 def _send_email(recipients, template):
-    email = make_email(from_address='noreply-indico-team@cern.ch', to_list=recipients, template=template, html=True)
+    from_address = CERNCronjobsPlugin.settings.get('sender_email')
+    email = make_email(from_address=from_address, to_list=recipients, template=template, html=True)
     send_email(email, module='Indico Cronjobs CERN')
 
 

--- a/cronjobs_cern/setup.cfg
+++ b/cronjobs_cern/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-cronjobs-cern
-version = 3.0
+version = 3.2-dev
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team
@@ -17,7 +17,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.9.0, <3.11
 install_requires =
-    indico>=3.0
+    indico>=3.2.dev0
 
 [options.entry_points]
 indico.plugins =


### PR DESCRIPTION
Instead of hardcoding a cern sender make the sending email configurable.