### PR TITLE
Let managers override 'all contribs' room capability check

### DIFF
--- a/audiovisual/indico_audiovisual/definition.py
+++ b/audiovisual/indico_audiovisual/definition.py
@@ -70,6 +70,8 @@ class AVRequest(RequestDefinitionBase):
         if 'webcast' not in req.data['services']:
             del form.custom_webcast_url
             del form.webcast_hidden
+        if req.event.type == 'lecture':
+            del form.ignore_capability
         return form
 
     @classmethod
@@ -104,6 +106,7 @@ class AVRequest(RequestDefinitionBase):
         super().manager_save(req, data)
         req.data['custom_webcast_url'] = data.get('custom_webcast_url')
         req.data['webcast_hidden'] = data.get('webcast_hidden', False)
+        req.data['ignore_capability'] = data.get('ignore_capability', False)
         flag_modified(req, 'data')
 
 

--- a/audiovisual/indico_audiovisual/forms.py
+++ b/audiovisual/indico_audiovisual/forms.py
@@ -84,6 +84,10 @@ class AVRequestManagerForm(RequestManagerForm):
                                                 "replaced with the ID of this event."))
     webcast_hidden = BooleanField(_('Hide webcast'),
                                   description=_('Do not show a link to the webcast on the event page'))
+    ignore_capability = BooleanField(_('Ignore room capability'),
+                                     description=_('If selected, "All contributions" will not skip those which take '
+                                                   'place in a room that does not support webcast/recording. This is '
+                                                   'especially useful for virtual events which have no physical room.'))
 
 
 class RequestListFilterForm(IndicoForm):

--- a/audiovisual/indico_audiovisual/util.py
+++ b/audiovisual/indico_audiovisual/util.py
@@ -126,7 +126,7 @@ def get_selected_contributions(req):
     contributions = get_contributions(req.event)
     if req.data.get('all_contributions', True):
         # "all contributions" includes only those in capable rooms
-        contributions = [x for x in contributions if x[1]]
+        contributions = [x for x in contributions if x[1] or req.data.get('ignore_capability')]
     else:
         selected = set(req.data['contributions'])
         contributions = [x for x in contributions if contribution_id(x[0]) in selected]

--- a/audiovisual/setup.cfg
+++ b/audiovisual/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-audiovisual
-version = 3.1
+version = 3.1.1
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team


### PR DESCRIPTION
Especially for larger events, having to manually select all contributions is not only annoying, but error-prone, since additional contributions may be added at a later point and those would not be included by default with a manual selection.

![image](https://user-images.githubusercontent.com/179599/155159524-7a556e51-7a72-40ec-8820-bd7315df4e0b.png)
