### PR TITLE
Audiovisual: Send initial email from the user

### DIFF
--- a/audiovisual/indico_audiovisual/plugin.py
+++ b/audiovisual/indico_audiovisual/plugin.py
@@ -41,6 +41,11 @@ from indico_audiovisual.views import WPAudiovisualManagers
 class PluginSettingsForm(IndicoForm):
     managers = PrincipalListField(_('Managers'), allow_groups=True,
                                   description=_('List of users who can manage recording/webcast requests.'))
+    initial_notification_emails = EmailListField(_('Initial notification email addresses'),
+                                                 description=_('Notifications about the initial submission of a '
+                                                               'recording/webcast request are sent to these '
+                                                               'email addresses (one per line). The sender for '
+                                                               'these emails is the user submitting the request.'))
     notification_emails = EmailListField(_('Notification email addresses'),
                                          description=_('Notifications about recording/webcast requests are sent to '
                                                        'these email addresses (one per line).'))
@@ -83,6 +88,7 @@ class AVRequestsPlugin(IndicoPlugin):
     settings_form = PluginSettingsForm
     default_settings = {'webcast_audiences': [],
                         'notification_reply_email': '',
+                        'initial_notification_emails': [],
                         'notification_emails': [],
                         'webcast_ping_url': '',
                         'webcast_url': '',

--- a/audiovisual/setup.cfg
+++ b/audiovisual/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-audiovisual
-version = 3.1.1
+version = 3.2
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team
@@ -17,7 +17,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.9.0, <3.11
 install_requires =
-    indico>=3.1
+    indico>=3.2.1.dev0
 
 [options.entry_points]
 indico.plugins =


### PR DESCRIPTION
Like this we can point it to a SNOW ticket email address so a new request creates a ticket. Behavior for emails on request withdrawal needs to be clarified with AV support; I don't think we can send a follow-up in the same ticket unless we record the message-ID, so the options are to either keep sending to the team address or opening yet another ticket in case of withdrawal.

depends on indico/indico#5501