### PR TITLE
Add CloudConvert support

### DIFF
--- a/conversion/indico_conversion/__init__.py
+++ b/conversion/indico_conversion/__init__.py
@@ -11,3 +11,4 @@ from indico.util.i18n import make_bound_gettext
 
 _ = make_bound_gettext('conversion')
 pdf_state_cache = make_scoped_cache('pdf-conversion')
+cloudconvert_task_cache = make_scoped_cache('pdf-conversion-cloudconvert-tasks')

--- a/conversion/indico_conversion/blueprint.py
+++ b/conversion/indico_conversion/blueprint.py
@@ -7,9 +7,12 @@
 
 from indico.core.plugins import IndicoPluginBlueprint
 
-from indico_conversion.conversion import RHConversionCheck, RHConversionFinished
+from indico_conversion.conversion import RHCloudConvertFinished, RHConversionCheck, RHDoconverterFinished
 
 
 blueprint = IndicoPluginBlueprint('conversion', __name__)
-blueprint.add_url_rule('/conversion/finished', 'callback', RHConversionFinished, methods=('POST',))
+blueprint.add_url_rule('/conversion/doconverter/finished', 'doconverter_callback',
+                       RHDoconverterFinished, methods=('POST',))
+blueprint.add_url_rule('/conversion/cloudconvert/finished', 'cloudconvert_callback',
+                       RHCloudConvertFinished, methods=('POST',))
 blueprint.add_url_rule('/conversion/check', 'check', RHConversionCheck)

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -1,5 +1,5 @@
 # This file is part of the CERN Indico plugins.
-# Copyright (C) 2014 - 2022 CERN
+# Copyright (C) 2014 - 2023 CERN
 #
 # The CERN Indico plugins are free software; you can redistribute
 # them and/or modify them under the terms of the MIT License; see

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -43,6 +43,18 @@ class Job(Resource):
 class Task(Resource):
     resource = 'tasks'
 
+    def upload(self, task, file):
+        if task['operation'] != 'import/upload':
+            raise Exception("The task operation is not import/upload")
+
+        form = task['result']['form']
+        with file.open() as fd:
+            response = requests.post(url=form['url'], files={'file': fd}, data=form['parameters'])
+            response.raise_for_status()
+            if response.status_code != 201:
+                raise requests.RequestException(f'Unexpected response status from server: {response.status_code}',
+                                                response=response)
+
 
 class CloudConvertRestClient:
     def __init__(self, *, api_key=None, sandbox=False):

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -44,17 +44,16 @@ class Job(Resource):
 class Task(Resource):
     resource = 'tasks'
 
-    def upload(self, task, file):
+    def upload(self, task, filename, fd, mimetype):
         if task['operation'] != 'import/upload':
             raise Exception("The task operation is not import/upload")
 
         form = task['result']['form']
-        with file.open() as fd:
-            response = requests.post(url=form['url'], files={'file': fd}, data=form['parameters'])
-            response.raise_for_status()
-            if response.status_code != 201:
-                raise requests.RequestException(f'Unexpected response status from server: {response.status_code}',
-                                                response=response)
+        response = requests.post(url=form['url'], files={'file': (filename, fd, mimetype)}, data=form['parameters'])
+        response.raise_for_status()
+        if response.status_code != 201:
+            raise requests.RequestException(f'Unexpected response status from server: {response.status_code}',
+                                            response=response)
 
 
 class CloudConvertRestClient:

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -1,0 +1,64 @@
+# This file is part of the CERN Indico plugins.
+# Copyright (C) 2014 - 2022 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+import requests
+
+
+endpoints = {
+    'live': 'https://api.cloudconvert.com/v2',
+    'sandbox': 'https://api.sandbox.cloudconvert.com/v2'
+}
+
+
+class Resource:
+    resource = None
+
+    def __init__(self, api_client):
+        self.api_client = api_client
+
+    def find(self, id):
+        url = f'{self.api_client.endpoint}/{self.resource}/{id}'
+        response = requests.get(url, headers=self.api_client.headers)
+        return self._process_response(response)
+
+    def create(self, payload):
+        url = f'{self.api_client.endpoint}/{self.resource}'
+        response = requests.post(url, json=payload, headers=self.api_client.headers)
+        return self._process_response(response)
+
+    def _process_response(self, response):
+        response.raise_for_status()
+        json = response.json()
+        return json.get('data', json)
+
+
+class Job(Resource):
+    resource = 'jobs'
+
+
+class Task(Resource):
+    resource = 'tasks'
+
+
+class CloudConvertRestClient:
+    def __init__(self, *, api_key=None, sandbox=False):
+        self.api_key = api_key
+        self.sandbox = sandbox
+        self.Job = Job(self)
+        self.Task = Task(self)
+
+    @property
+    def endpoint(self):
+        return endpoints['sandbox' if self.sandbox else 'live']
+
+    @property
+    def headers(self):
+        return {
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -10,7 +10,8 @@ import requests
 
 endpoints = {
     'live': 'https://api.cloudconvert.com/v2',
-    'sandbox': 'https://api.sandbox.cloudconvert.com/v2'
+    'sandbox': 'https://api.sandbox.cloudconvert.com/v2',
+    'user': 'https://api.cloudconvert.com/v2/users/me'
 }
 
 
@@ -74,3 +75,8 @@ class CloudConvertRestClient:
             'Content-Type': 'application/json',
             'Accept': 'application/json',
         }
+
+    def get_remaining_credits(self):
+        response = requests.get(endpoints['user'], headers=self.headers)
+        response.raise_for_status()
+        return response.json()['data']['credits']

--- a/conversion/indico_conversion/cloudconvert.py
+++ b/conversion/indico_conversion/cloudconvert.py
@@ -44,6 +44,11 @@ class Job(Resource):
 class Task(Resource):
     resource = 'tasks'
 
+    def find(self, id):
+        url = f'{self.api_client.endpoint}/{self.resource}/{id}'
+        response = requests.get(url, headers=self.api_client.headers)
+        return self._process_response(response)
+
     def upload(self, task, filename, fd, mimetype):
         if task['operation'] != 'import/upload':
             raise Exception("The task operation is not import/upload")

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -127,7 +127,7 @@ def submit_attachment_cloudconvert(task, attachment):
     import_task = f'import-file-{attachment.id}'
     convert_task = f'convert-file-{attachment.id}'
     export_task = f'export-file-{attachment.id}'
-    signed_id = secure_serializer.dumps(str(attachment.id), salt='pdf-conversion')
+    signed_id = secure_serializer.dumps(attachment.id, salt='pdf-conversion')
 
     job_definition = {
         'tag': f'{attachment.file.id}__{signed_id}',
@@ -229,12 +229,11 @@ class RHCloudConvertFinished(RH):
 
         try:
             signed_id = job['tag'].split('__', 1)[1]
-            payload = secure_serializer.loads(signed_id, salt='pdf-conversion')
+            attachment_id = secure_serializer.loads(signed_id, salt='pdf-conversion')
         except (IndexError, BadData):
             ConversionPlugin.logger.exception('Received invalid payload (%s)', job['tag'])
             return jsonify(success=False)
 
-        attachment_id = int(payload)
         attachment = Attachment.get(attachment_id)
         if not attachment or attachment.is_deleted or attachment.folder.is_deleted:
             ConversionPlugin.logger.info('Attachment has been deleted: %s', attachment)

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -211,13 +211,16 @@ def check_cloudconvert_credits(task):
     notify_threshold = ConversionPlugin.settings.get('notify_threshold')
     notify_email = ConversionPlugin.settings.get('notify_email')
 
+    if notify_threshold is None:
+        return
+
     try:
         credits = client.get_remaining_credits()
     except requests.RequestException as err:
         ConversionPlugin.logger.info('Could not fetch the remaining CloudConvert credits: %s', err)
         task.retry(countdown=60)
 
-    if notify_threshold is not None and credits <= notify_threshold:
+    if credits <= notify_threshold:
         ConversionPlugin.logger.info('CloudConvert credits are below configured threshold; current value: %s', credits)
         if notify_email:
             plugin_settings_url = url_for('plugins.details', plugin=ConversionPlugin.name, _external=True)

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -120,7 +120,7 @@ def submit_attachment_cloudconvert(task, attachment):
         task.retry(countdown=900)
 
     api_key = ConversionPlugin.settings.get('cloudconvert_api_key')
-    sandbox = ConversionPlugin.settings.get('sandbox')
+    sandbox = ConversionPlugin.settings.get('cloudconvert_sandbox')
     client = CloudConvertRestClient(api_key=api_key, sandbox=sandbox)
 
     import_task = f'import-file-{attachment.id}'
@@ -217,8 +217,8 @@ def check_cloudconvert_credits(task):
 
     api_key = ConversionPlugin.settings.get('cloudconvert_api_key')
     client = CloudConvertRestClient(api_key=api_key, sandbox=False)
-    notify_threshold = ConversionPlugin.settings.get('notify_threshold')
-    notify_email = ConversionPlugin.settings.get('notify_email')
+    notify_threshold = ConversionPlugin.settings.get('cloudconvert_notify_threshold')
+    notify_email = ConversionPlugin.settings.get('cloudconvert_notify_email')
 
     if notify_threshold is None:
         return

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -229,11 +229,13 @@ def check_cloudconvert_credits(task):
         ConversionPlugin.logger.info('Could not fetch the remaining CloudConvert credits: %s', err)
         task.retry(countdown=60)
 
-    if credits <= notify_threshold:
-        ConversionPlugin.logger.info('CloudConvert credits are below configured threshold; current value: %s', credits)
+    if credits < notify_threshold:
+        ConversionPlugin.logger.warning('CloudConvert credits below configured threshold; current value: %s', credits)
         if notify_email:
             plugin_settings_url = url_for('plugins.details', plugin=ConversionPlugin.name, _external=True)
             template = get_template_module('conversion:emails/cloudconvert_low_credits.html', credits=credits,
                                            plugin_settings_url=plugin_settings_url)
             email = make_email(to_list=notify_email, template=template, html=True)
             send_email(email)
+    else:
+        ConversionPlugin.logger.info('CloudConvert credits: %s', credits)

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -173,7 +173,7 @@ class RHCloudConvertFinished(RH):
             return jsonify(success=False)
 
         job = request.json['job']
-        task = [t for t in job['tasks'] if t['name'] == 'export-my-file'][0]
+        task = [t for t in job['tasks'] if t['operation'] == 'export/url'][0]
         url = task['result']['files'][0]['url']
 
         try:

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -144,7 +144,8 @@ def submit_attachment_cloudconvert(task, attachment):
         job = client.Job.create(payload=job_definition)
         upload_task_id = job['tasks'][0]['id']
         task = client.Task.find(id=upload_task_id)
-        client.Task.upload(task, attachment.file)
+        with attachment.file.open() as fd:
+            client.Task.upload(task, attachment.file.filename, fd, attachment.file.content_type)
     except requests.RequestException as exc:
         retry_task(task, attachment, exc)
     else:

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -130,7 +130,7 @@ def submit_attachment_cloudconvert(task, attachment):
     signed_id = secure_serializer.dumps(attachment.id, salt='pdf-conversion')
 
     job_definition = {
-        'tag': f'{attachment.file.id}__{signed_id}',
+        'tag': f'{attachment.id}__{signed_id}',
         'tasks': {
             import_task: {
                 'operation': 'import/upload',

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -45,12 +45,14 @@ def retry_task(task, attachment, exception):
     try:
         task.retry(countdown=delay, max_retries=(MAX_TRIES - 1))
     except MaxRetriesExceededError:
-        ConversionPlugin.logger.error('Could not submit attachment %d (attempt %d/%d); giving up [%s]:[%s]',
-                                      attachment.id, attempt, MAX_TRIES, exception, exception.response.text)
+        response_text = exception.response.text if exception.response else '<no response>'
+        ConversionPlugin.logger.error('Could not submit attachment %d (attempt %d/%d); giving up [%s]: %s',
+                                      attachment.id, attempt, MAX_TRIES, exception, response_text)
         pdf_state_cache.delete(str(attachment.id))
     except Retry:
-        ConversionPlugin.logger.warning('Could not submit attachment %d (attempt %d/%d); retry in %ds [%s]:[%s]',
-                                        attachment.id, attempt, MAX_TRIES, delay, exception, exception.response.text)
+        response_text = exception.response.text if exception.response else '<no response>'
+        ConversionPlugin.logger.warning('Could not submit attachment %d (attempt %d/%d); retry in %ds [%s]: %s',
+                                        attachment.id, attempt, MAX_TRIES, delay, exception, response_text)
         raise
 
 

--- a/conversion/indico_conversion/conversion.py
+++ b/conversion/indico_conversion/conversion.py
@@ -216,6 +216,7 @@ def check_attachment_cloudconvert(task, attachment_id, export_task_id):
     attachment = Attachment.get(attachment_id)
     if not attachment or attachment.is_deleted or attachment.folder.is_deleted:
         ConversionPlugin.logger.info('Attachment has been deleted: %s', attachment)
+        cloudconvert_task_cache.delete(export_task_id)
         return
     resp = requests.get(url)
     try:
@@ -259,6 +260,7 @@ class RHCloudConvertFinished(RH):
         attachment = Attachment.get(attachment_id)
         if not attachment or attachment.is_deleted or attachment.folder.is_deleted:
             ConversionPlugin.logger.info('Attachment has been deleted: %s', attachment)
+            cloudconvert_task_cache.set(task['id'], 'done', 3600)
             return jsonify(success=True)
 
         # make sure polling task doesn't also process the file in case of a race condition

--- a/conversion/indico_conversion/plugin.py
+++ b/conversion/indico_conversion/plugin.py
@@ -117,7 +117,7 @@ class ConversionPlugin(IndicoPlugin):
         # Prepare for submission (after commit)
         if 'convert_attachments' not in g:
             g.convert_attachments = set()
-        g.convert_attachments.add(attachment)
+        g.convert_attachments.add((attachment, attachment.is_protected))
         # Set cache entry to show the pending attachment
         pdf_state_cache.set(str(attachment.id), 'pending', timeout=info_ttl)
         if not g.get('attachment_conversion_msg_displayed'):
@@ -126,8 +126,8 @@ class ConversionPlugin(IndicoPlugin):
                     'automatically once the conversion finished.').format(file=attachment.file.filename))
 
     def _after_commit(self, sender, **kwargs):
-        for attachment in g.get('convert_attachments', ()):
-            if self.settings.get('use_cloudconvert') and not attachment.is_protected:
+        for attachment, is_protected in g.get('convert_attachments', ()):
+            if self.settings.get('use_cloudconvert') and not is_protected:
                 submit_attachment_cloudconvert.delay(attachment)
             else:
                 submit_attachment_doconverter.delay(attachment)

--- a/conversion/indico_conversion/plugin.py
+++ b/conversion/indico_conversion/plugin.py
@@ -34,7 +34,7 @@ info_ttl = timedelta(hours=1)
 
 class SettingsForm(IndicoForm):
     use_cloudconvert = BooleanField(_('Use CloudConvert'), widget=SwitchWidget(),
-                                    description=_('Use Cloudconvert instead of Doconverter'))
+                                    description=_('Use Cloudconvert instead of Doconverter for public materials'))
     maintenance = BooleanField(_('Maintenance'), widget=SwitchWidget(),
                                description=_('Temporarily disable submitting files. The tasks will be kept and once '
                                              'this setting is disabled the files will be submitted.'))
@@ -122,7 +122,7 @@ class ConversionPlugin(IndicoPlugin):
 
     def _after_commit(self, sender, **kwargs):
         for attachment in g.get('convert_attachments', ()):
-            if self.settings.get('use_cloudconvert'):
+            if self.settings.get('use_cloudconvert') and not attachment.is_protected:
                 submit_attachment_cloudconvert.delay(attachment)
             else:
                 submit_attachment_doconverter.delay(attachment)

--- a/conversion/indico_conversion/templates/emails/cloudconvert_low_credits.html
+++ b/conversion/indico_conversion/templates/emails/cloudconvert_low_credits.html
@@ -1,0 +1,14 @@
+{% extends 'emails/base.html' %}
+
+{% block subject %}[CloudConvert plugin] Low credits{% endblock %}
+
+{% block header_recipient %}Indico Administrators{% endblock %}
+
+{% block body -%}
+    <p>
+        The available credits for the CloudConvert plugin have dropped below the configured threshold.<br>
+        Number of credits remaining: <b>{{ credits }}</b><br>
+        You should either buy more credits or disable the CloudConvert conversion.<br>
+        You can manage the plugin from here: <a href="{{ plugin_settings_url }}">{{ plugin_settings_url }}</a>
+    </p>
+{%- endblock %}

--- a/conversion/indico_conversion/templates/emails/cloudconvert_low_credits.html
+++ b/conversion/indico_conversion/templates/emails/cloudconvert_low_credits.html
@@ -1,6 +1,6 @@
 {% extends 'emails/base.html' %}
 
-{% block subject %}[CloudConvert plugin] Low credits{% endblock %}
+{% block subject %}Low CloudConvert credits{% endblock %}
 
 {% block header_recipient %}Indico Administrators{% endblock %}
 

--- a/conversion/indico_conversion/util.py
+++ b/conversion/indico_conversion/util.py
@@ -6,6 +6,13 @@
 # the LICENSE file for more details.
 
 import os
+from datetime import timedelta
+
+from indico.core import signals
+from indico.core.db import db
+from indico.modules.attachments.models.attachments import Attachment, AttachmentFile, AttachmentType
+
+from indico_conversion import pdf_state_cache
 
 
 def get_pdf_title(attachment):
@@ -14,3 +21,20 @@ def get_pdf_title(attachment):
         return attachment.title[:-len(ext)] + '.pdf'
     else:
         return attachment.title
+
+
+def save_pdf(attachment, pdf):
+    from indico_conversion.plugin import ConversionPlugin
+    name, ext = os.path.splitext(attachment.file.filename)
+    title = get_pdf_title(attachment)
+    pdf_attachment = Attachment(folder=attachment.folder, user=attachment.user, title=title,
+                                description=attachment.description, type=AttachmentType.file,
+                                protection_mode=attachment.protection_mode, acl=attachment.acl)
+    pdf_attachment.file = AttachmentFile(user=attachment.file.user, filename=f'{name}.pdf',
+                                         content_type='application/pdf')
+    pdf_attachment.file.save(pdf)
+    db.session.add(pdf_attachment)
+    db.session.flush()
+    pdf_state_cache.set(str(attachment.id), 'finished', timeout=timedelta(minutes=15))
+    ConversionPlugin.logger.info('Added PDF attachment %s for %s', pdf_attachment, attachment)
+    signals.attachments.attachment_created.send(pdf_attachment, user=None)

--- a/conversion/setup.cfg
+++ b/conversion/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-conversion
-version = 3.2
+version = 3.2.1
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team


### PR DESCRIPTION
Adds experimental CloudConvert support to the conversion plugin.
Feedback welcome!

### How to test this:
- Make an account on CloudConvert and create an API key (you can also use the sandbox API which doesn't count towards the limit: https://cloudconvert.com/api/v2#overview, but then you can only upload limited files based on an md5 hash)
- Enable CloudConvert instead of Doconverter and set the API key in the Conversion plugin setttings.
- Make sure the webhook (`/conversion/cloudconvert/finished`) is reachable by cloudconvert (use ngrok for reverse proxy if needed)
- Upload a file with a supported extension (e.g. `docx`) and toggle `Convert to PDF`
- Wait & Pray
