### PR TITLE
Make the RUCIO logo fit in the event header

### DIFF
--- a/themes_cern/indico_themes_cern/themes/rucio.scss
+++ b/themes_cern/indico_themes_cern/themes/rucio.scss
@@ -6,7 +6,7 @@ $header-text-color: $light-gray;
 
 @import 'themes/indico';
 
-@include header-logo('themes_cern:rucio_logo.png', 15px, 200px, 12%);
+@include header-logo('themes_cern:rucio_logo.png', 15px, 200px, 10%);
 
 .event-header .details {
   [class^='icon-']::before,

--- a/themes_cern/setup.cfg
+++ b/themes_cern/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-themes-cern
-version = 3.2.1
+version = 3.2.2
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team


### PR DESCRIPTION
before:
![image](https://github.com/indico/indico-plugins-cern/assets/8739637/e6788b36-b405-454f-a764-44bba223995c)


after:
![image](https://github.com/indico/indico-plugins-cern/assets/8739637/d4687c47-dc54-4232-a378-c862303e4650)
