### PR TITLE
FoundationSync: Use oracledb instead of cx_Oracle

### DIFF
--- a/foundationsync/setup.cfg
+++ b/foundationsync/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-foundationsync
-version = 3.1
+version = 3.1.1
 url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team
@@ -19,7 +19,7 @@ include_package_data = true
 python_requires = >=3.9.0, <3.11
 install_requires =
     indico>=3.1
-    cx_Oracle>=8.3.0,<9
+    oracledb>=1.3.2,<2
 
 [options.entry_points]
 indico.plugins =


### PR DESCRIPTION
`oracledb` is the successor of `cx_Oracle` and besides being newer it has some advantages. For example, it supports "thin mode" which does not require `oracle-instantclient` to be installed on the system.