### PR TITLE
CERNAccess: Use larger date range for the birth date field

### DIFF
--- a/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
+++ b/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
@@ -159,6 +159,8 @@ export default function RegistrationIdentityDataForm({
         isOutsideRange={value => value.isAfter()}
         enableOutsideDays
         placeholder={moment.localeData().longDateFormat('L')}
+        yearsBefore={120}
+        yearsAfter={0}
       />
       <CERNAccessItem
         name="cern_access_nationality"

--- a/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
+++ b/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
@@ -89,6 +89,8 @@ function AccompanyingPersonsComponent({onChange, value, countryOptions, accompan
                 onDateChange={date => handleOnChange(id, 'birth_date', serializeDate(date))}
                 enableOutsideDays
                 required
+                yearsBefore={100}
+                yearsAfter={0}
               />
             </td>
             <td>

--- a/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
+++ b/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
@@ -159,7 +159,7 @@ export default function RegistrationIdentityDataForm({
         isOutsideRange={value => value.isAfter()}
         enableOutsideDays
         placeholder={moment.localeData().longDateFormat('L')}
-        yearsBefore={120}
+        yearsBefore={100}
         yearsAfter={0}
       />
       <CERNAccessItem


### PR DESCRIPTION
The default is 5 before and 5 after which is not very useful if the date picker is used to select a birth date.
This changes the range to 1904-2024.