### PR TITLE
Add i18n-demo plugin

### DIFF
--- a/i18n_demo/MANIFEST.in
+++ b/i18n_demo/MANIFEST.in
@@ -1,0 +1,3 @@
+graft indico_i18n_demo/templates
+
+global-exclude *.pyc __pycache__ .keep

--- a/i18n_demo/README.md
+++ b/i18n_demo/README.md
@@ -1,8 +1,13 @@
 # indico-plugin-i18n-demo
 
-This is a plugin intended for the [i18n demo instance](https://localization-demo.getindico.io). It does two things:
+This is a plugin intended for the [i18n demo
+instance](https://localization-demo.getindico.io). It does two things:
 
-- All emails are redirected to the user who sent them (avoids spamming random people and lets you check email translations)
-- Adds a new **Clone** button to the example events. When clicked, the corresponding event is cloned into your own personal subcategory and you get management rights to it. This way, you can see the management area without accidentally modifying the example events.
+- All emails are redirected to the user who sent them (avoids spamming random
+  people and lets you check email translations)
+- Adds a new **Clone** button to the example events. When clicked, the
+  corresponding event is cloned into your own personal subcategory and you get
+  management rights to it. This way, you can see the management area without
+  accidentally modifying the example events.
 
 ![](example.png)

--- a/i18n_demo/README.md
+++ b/i18n_demo/README.md
@@ -1,0 +1,8 @@
+# indico-plugin-i18n-demo
+
+This is a plugin intended for the [i18n demo instance](https://localization-demo.getindico.io). It does two things:
+
+- All emails are redirected to the user who sent them (avoids spamming random people and lets you check email translations)
+- Adds a new **Clone** button to the example events. When clicked, the corresponding event is cloned into your own personal subcategory and you get management rights to it. This way, you can see the management area without accidentally modifying the example events.
+
+![](example.png)

--- a/i18n_demo/indico_i18n_demo/blueprint.py
+++ b/i18n_demo/indico_i18n_demo/blueprint.py
@@ -1,0 +1,15 @@
+# This file is part of the CERN Indico plugins.
+# Copyright (C) 2014 - 2024 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+from indico.core.plugins import IndicoPluginBlueprint
+
+from indico_i18n_demo.controllers import RHCloneEvent
+
+
+blueprint = IndicoPluginBlueprint('i18n_demo', __name__, url_prefix='/i18n-demo')
+
+blueprint.add_url_rule('/event/<int:event_id>/clone', 'clone_event', RHCloneEvent, methods=('POST',))

--- a/i18n_demo/indico_i18n_demo/controllers.py
+++ b/i18n_demo/indico_i18n_demo/controllers.py
@@ -1,0 +1,62 @@
+# This file is part of the CERN Indico plugins.
+# Copyright (C) 2014 - 2024 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+from flask import flash, redirect, session
+from flask_pluginengine import current_plugin
+from werkzeug.exceptions import BadRequest
+
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.modules.categories.models.categories import Category
+from indico.modules.categories.operations import create_category as _create_category
+from indico.modules.events.cloning import get_event_cloners
+from indico.modules.events.controllers.base import RHEventBase
+from indico.modules.events.operations import clone_event
+from indico.web.flask.util import url_for
+
+
+class RHCloneEvent(RHEventBase):
+    """Clone an event to a user's personal category.
+
+    If the category does not exist, it will be created.
+    The user has full management rights within the category.
+    """
+    ALLOW_LOCKED = True
+
+    def _process(self):
+        if not (category_id := current_plugin.settings.get('test_category_id')):
+            raise BadRequest('No test category ID configured')
+
+        test_category = Category.get(int(category_id))
+        user_category = get_user_category(test_category, session.user)
+
+        cloners = {c for c in get_event_cloners().values() if not c.is_internal}
+        new_event = clone_event(self.event, n_occurrence=0, start_dt=self.event.start_dt, cloners=cloners,
+                                category=user_category, refresh_users=False)
+
+        flash('Event successfully cloned!', 'success')
+        return redirect(url_for('event_management.settings', new_event))
+
+
+def get_user_category(parent, user):
+    category = Category.query.filter(Category.title == get_category_title(user)).first()
+    if category:
+        if category.is_deleted:
+            category.is_deleted = False
+        return category
+    return create_category(parent, user)
+
+
+def create_category(parent, user):
+    description = 'This is your own category where you have full management rights. Have fun!'
+    category = _create_category(parent, {'title': get_category_title(user), 'description': description})
+    category.protection_mode = ProtectionMode.protected
+    category.update_principal(user, full_access=True)
+    return category
+
+
+def get_category_title(user):
+    return f"{user.full_name}'s category ({user.id})"

--- a/i18n_demo/indico_i18n_demo/controllers.py
+++ b/i18n_demo/indico_i18n_demo/controllers.py
@@ -42,7 +42,7 @@ class RHCloneEvent(RHEventBase):
 
 
 def get_user_category(parent, user):
-    category = Category.query.filter(Category.title == get_category_title(user)).first()
+    category = Category.query.filter_by(title=get_category_title(user)).first()
     if category:
         if category.is_deleted:
             category.is_deleted = False

--- a/i18n_demo/indico_i18n_demo/plugin.py
+++ b/i18n_demo/indico_i18n_demo/plugin.py
@@ -1,0 +1,73 @@
+# This file is part of the CERN Indico plugins.
+# Copyright (C) 2014 - 2024 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+from flask import session
+from flask_pluginengine.plugin import render_plugin_template
+from wtforms.fields import IntegerField
+from wtforms.validators import NumberRange, Optional
+
+from indico.core import signals
+from indico.core.config import config
+from indico.core.notifications import make_email
+from indico.core.plugins import IndicoPlugin
+from indico.modules.categories.models.categories import Category
+from indico.util.signals import interceptable_sender
+from indico.web.forms.base import IndicoForm
+
+from indico_i18n_demo.blueprint import blueprint
+
+
+class PluginSettingsForm(IndicoForm):
+    test_category_id = IntegerField('Test category ID', [Optional(), NumberRange(min=1)],
+                                    description='The ID of the category to clone events to')
+
+
+class I18nDemoPlugin(IndicoPlugin):
+    """I18n Demo
+
+    Provides utilities for the i18n-demo instance.
+    """
+
+    configurable = True
+    settings_form = PluginSettingsForm
+    default_settings = {
+        'test_category_id': ''
+    }
+
+    def init(self):
+        super().init()
+        self.template_hook('event-status-labels', self._inject_clone_button)
+        self.connect(signals.plugin.interceptable_function, self._intercept_make_email,
+                     sender=interceptable_sender(make_email))
+
+    def get_blueprints(self):
+        return blueprint
+
+    def _inject_clone_button(self, event, **kwargs):
+        if not (test_category_id := self.settings.get('test_category_id')):
+            return
+
+        if not (test_category := Category.get(int(test_category_id))):
+            return
+
+        if event.category != test_category and not event.category.is_descendant_of(test_category):
+            return render_plugin_template('clone_button.html', event=event)
+
+    def _intercept_make_email(self, sender, func, args, **kwargs):
+        ret = func(**args.arguments)
+
+        return {
+            'to': {session.user.email},
+            'cc': set(),
+            'bcc': set(),
+            'from': config.NO_REPLY_EMAIL,
+            'reply_to': set(),
+            'attachments': ret['attachments'],
+            'subject': ret['subject'],
+            'body': ret['body'],
+            'html': ret['html'],
+        }

--- a/i18n_demo/indico_i18n_demo/plugin.py
+++ b/i18n_demo/indico_i18n_demo/plugin.py
@@ -60,7 +60,7 @@ class I18nDemoPlugin(IndicoPlugin):
     def _intercept_make_email(self, sender, func, args, **kwargs):
         ret = func(**args.arguments)
 
-        return {
+        return ret | {
             'to': {session.user.email},
             'cc': set(),
             'bcc': set(),

--- a/i18n_demo/indico_i18n_demo/plugin.py
+++ b/i18n_demo/indico_i18n_demo/plugin.py
@@ -5,7 +5,7 @@
 # them and/or modify them under the terms of the MIT License; see
 # the LICENSE file for more details.
 
-from flask import session, has_request_context
+from flask import has_request_context, session
 from flask_pluginengine.plugin import render_plugin_template
 from wtforms.fields import IntegerField
 from wtforms.validators import NumberRange, Optional

--- a/i18n_demo/indico_i18n_demo/templates/clone_button.html
+++ b/i18n_demo/indico_i18n_demo/templates/clone_button.html
@@ -1,0 +1,9 @@
+<button type="button"
+        class="ui tiny compact button ui-qtip"
+        style="margin-left: 2em;"
+        title="Clone event into your personal category with full management rights"
+        data-href="{{ url_for('plugin_i18n_demo.clone_event', event) }}"
+        data-method="POST">
+    <i aria-hidden="true" class="icon clone alternate"></i>
+    Clone
+</button>

--- a/i18n_demo/setup.cfg
+++ b/i18n_demo/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = indico-plugin-i18n-demo
+version = 3.3-dev
+description = Indico plugin to sanitize a database for testing
+url = https://github.com/indico/indico-plugins-cern/i18n-demo
+license = MIT
+author = Indico Team
+author_email = indico-team@cern.ch
+classifiers =
+    Environment :: Plugins
+    Environment :: Web Environment
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3.12
+
+[options]
+packages = find:
+zip_safe = false
+include_package_data = true
+python_requires = >=3.12, <3.13
+install_requires =
+    indico>=3.3.2-dev0
+
+[options.entry_points]
+indico.plugins =
+    i18n_demo = indico_i18n_demo.plugin:I18nDemoPlugin
+
+[pydocstyle]
+ignore = D100,D101,D102,D103,D104,D105,D107,D203,D213

--- a/i18n_demo/setup.cfg
+++ b/i18n_demo/setup.cfg
@@ -1,8 +1,7 @@
 [metadata]
 name = indico-plugin-i18n-demo
 version = 3.3-dev
-description = Indico plugin to sanitize a database for testing
-url = https://github.com/indico/indico-plugins-cern/i18n-demo
+url = https://github.com/indico/indico-plugins-cern
 license = MIT
 author = Indico Team
 author_email = indico-team@cern.ch
@@ -18,7 +17,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.12, <3.13
 install_requires =
-    indico>=3.3.2-dev0
+    indico>=3.3
 
 [options.entry_points]
 indico.plugins =

--- a/i18n_demo/setup.py
+++ b/i18n_demo/setup.py
@@ -1,0 +1,11 @@
+# This file is part of the CERN Indico plugins.
+# Copyright (C) 2014 - 2024 CERN
+#
+# The CERN Indico plugins are free software; you can redistribute
+# them and/or modify them under the terms of the MIT License; see
+# the LICENSE file for more details.
+
+from setuptools import setup
+
+
+setup()


### PR DESCRIPTION
This is a plugin intended for the [i18n demo instance](https://localization-demo.getindico.io). It does two things:

- All emails are redirected to the user who sent them (avoids spamming random people and lets you check email translations)
- Adds a new **Clone** button to the example events. When clicked, the corresponding event is cloned into your own personal subcategory and you get management rights to it. This way, you can see the management area without accidentally modifying the example events.

![image](https://github.com/indico/indico-plugins-cern/assets/8739637/edc0ff96-d737-48d5-85f2-adad7937cba0)