### PR TITLE
Burotel: Hide repeating timeline style

### DIFF
--- a/burotel/indico_burotel/client/js/parametrized.jsx
+++ b/burotel/indico_burotel/client/js/parametrized.jsx
@@ -124,6 +124,7 @@ const Calendar = parametrize(DefaultCalendar, {
 
 const TimelineItem = parametrize(DefaultTimelineItem, {
   dayBased: true,
+  hideRepeatingTimeline: true,
 });
 
 const BookingEditForm = parametrize(DefaultBookingEditForm, {


### PR DESCRIPTION
This PR adds a flag to Burotel to disable the repeating timeline style for bookings.