### PR TITLE
Fix merchant reference to only contain printable ascii

### DIFF
--- a/payment_cern/indico_payment_cern/tests/util_test.py
+++ b/payment_cern/indico_payment_cern/tests/util_test.py
@@ -17,6 +17,10 @@ from indico_payment_cern.util import get_order_id
     (123, 456, 'x', 'Foo Bar',                         'XBARFOOc123r456'),
     (123, 456, '',  'FooVeryLongName BarVeryLongName', 'BARVERYLONGNAMEFOOVERYc123r456'),
     (123, 456, 'x', 'FooVeryLongName BarVeryLongName', 'XBARVERYLONGNAMEFOOVERc123r456'),
+    (123, 456, 'x', 'Björn Groß', 'XGROSSBJOERNc123r456'),
+    (123, 456, 'x', 'Søren Åkesson', 'XAAKESSONSORENc123r456'),
+    (123, 456, 'x', 'Tomáš Dvořák', 'XDVORAKTOMASc123r456'),
+    (123, 456, 'x', 'けんじ 中村', 'Xc123r456'),  # XXX: This results in an empty order ID
 ))
 def test_get_order_id(event_id, registration_id, prefix, name, expected):
     first_name, last_name = name.split(' ', 1)

--- a/payment_cern/indico_payment_cern/util.py
+++ b/payment_cern/indico_payment_cern/util.py
@@ -7,7 +7,7 @@
 
 from flask_pluginengine import current_plugin
 
-from indico.util.string import remove_accents, remove_non_alpha
+from indico.util.string import remove_non_alpha, str_to_ascii
 
 
 def get_payment_methods(event, currency):
@@ -49,5 +49,5 @@ def get_order_id(registration, prefix, max_len=30):
     """
     payment_id = f'c{registration.event_id}r{registration.id}'
     order_id_extra_len = max_len - len(payment_id)
-    order_id = prefix + remove_non_alpha(remove_accents(registration.last_name + registration.first_name))
+    order_id = prefix + remove_non_alpha(str_to_ascii(registration.last_name + registration.first_name))
     return order_id[:order_id_extra_len].upper().strip() + payment_id


### PR DESCRIPTION
Postfinance requires that merchant reference only contains printable ascii characters.