### PR TITLE
Allow custom reminders/times

### DIFF
--- a/outlook/indico_outlook/calendar.py
+++ b/outlook/indico_outlook/calendar.py
@@ -70,7 +70,7 @@ def _get_status(user, event, settings):
     status = OutlookPlugin.user_settings.get(user, 'status', settings['status'])
     for override in OutlookPlugin.user_settings.get(user, 'overrides'):
         if override['type'] == 'category' and override['id'] == event.category_id:
-            # we don't keep going for a specific category Id match
+            # we don't keep going for a specific category id match
             return override['status']
         elif override['type'] == 'category_tree' and override['id'] in event.category_chain:
             # for category tree matches we keep going in case there's a specific match later.
@@ -85,7 +85,7 @@ def _get_reminder(user, event, settings):
     reminder_minutes = OutlookPlugin.user_settings.get(user, 'reminder_minutes', settings['reminder_minutes'])
     for override in OutlookPlugin.user_settings.get(user, 'overrides'):
         if override['type'] == 'category' and override['id'] == event.category_id:
-            # we don't keep going for a specific category Id match
+            # we don't keep going for a specific category id match
             return override.get('reminder', reminder), override.get('reminder_minutes', reminder_minutes)
         elif override['type'] == 'category_tree' and override['id'] in event.category_chain:
             # for category tree matches we keep going in case there's a specific match later.

--- a/outlook/indico_outlook/calendar.py
+++ b/outlook/indico_outlook/calendar.py
@@ -68,16 +68,30 @@ def update_calendar():
 def _get_status(user, event, settings):
     from indico_outlook.plugin import OutlookPlugin
     status = OutlookPlugin.user_settings.get(user, 'status', settings['status'])
-    for override in OutlookPlugin.user_settings.get(user, 'status_overrides'):
-        if override['type'] == 'category' and override['id'] == event.category_id:
+    for override in OutlookPlugin.user_settings.get(user, 'overrides'):
+        if override['type'] == 'category' and override['id'] == event.category_id and not override['status']:
             # we don't keep going for a specific category Id match
             return override['status']
-        elif override['type'] == 'category_tree' and override['id'] in event.category_chain:
+        elif override['type'] == 'category_tree' and override['id'] in event.category_chain and not override['status']:
             # for category tree matches we keep going in case there's a specific match later.
-            # we don't try to see which one is more specific becauase that'd be overkill!
+            # we don't try to see which one is more specific because that'd be overkill!
             status = override['status']
     return status
 
+
+def _get_reminder(user, event, settings):
+    from indico_outlook.plugin import OutlookPlugin
+    reminder = OutlookPlugin.user_settings.get(user, 'reminder', settings['reminder'])
+    reminder_minutes = OutlookPlugin.user_settings.get(user, 'reminder_minutes', settings['reminder_minutes'])
+    for override in OutlookPlugin.user_settings.get(user, 'overrides'):
+        if override['type'] == 'category' and override['id'] == event.category_id:
+            # we don't keep going for a specific category Id match
+            return override.get('reminder', reminder), override.get('reminder_minutes', reminder_minutes)
+        elif override['type'] == 'category_tree' and override['id'] in event.category_chain:
+            # for category tree matches we keep going in case there's a specific match later.
+            # we don't try to see which one is more specific becauase that'd be overkill!
+            reminder = override.get('reminder', reminder), override.get('reminder_minutes', reminder_minutes)
+    return reminder, reminder_minutes
 
 def _update_calendar_entry(entry, settings):
     """Executes a single calendar update
@@ -109,6 +123,7 @@ def _update_calendar_entry(entry, settings):
         location = strip_control_chars(event.room_name)
         description = strip_control_chars(event.description)
         event_url = event.external_url
+        reminder, reminder_minutes = _get_reminder(user, event, settings)
         data = {
             'status': _get_status(user, event, settings),
             'start': int(event.start_dt.timestamp()),
@@ -117,8 +132,8 @@ def _update_calendar_entry(entry, settings):
             # XXX: the API expects 'body', we convert it below
             'description': f'<a href="{event_url}">{event_url}</a><br><br>{description}',
             'location': location,
-            'reminder_on': settings['reminder'],
-            'reminder_minutes': settings['reminder_minutes']
+            'reminder_on': reminder,
+            'reminder_minutes': reminder_minutes,
         }
 
         # check whether the plugins want to add/override any data

--- a/outlook/indico_outlook/calendar.py
+++ b/outlook/indico_outlook/calendar.py
@@ -69,10 +69,10 @@ def _get_status(user, event, settings):
     from indico_outlook.plugin import OutlookPlugin
     status = OutlookPlugin.user_settings.get(user, 'status', settings['status'])
     for override in OutlookPlugin.user_settings.get(user, 'overrides'):
-        if override['type'] == 'category' and override['id'] == event.category_id and not override['status']:
+        if override['type'] == 'category' and override['id'] == event.category_id:
             # we don't keep going for a specific category Id match
             return override['status']
-        elif override['type'] == 'category_tree' and override['id'] in event.category_chain and not override['status']:
+        elif override['type'] == 'category_tree' and override['id'] in event.category_chain:
             # for category tree matches we keep going in case there's a specific match later.
             # we don't try to see which one is more specific because that'd be overkill!
             status = override['status']

--- a/outlook/indico_outlook/calendar.py
+++ b/outlook/indico_outlook/calendar.py
@@ -93,6 +93,7 @@ def _get_reminder(user, event, settings):
             reminder = override.get('reminder', reminder), override.get('reminder_minutes', reminder_minutes)
     return reminder, reminder_minutes
 
+
 def _update_calendar_entry(entry, settings):
     """Executes a single calendar update
 

--- a/outlook/indico_outlook/migrations/20241117_1113_da9deaa182a4_update_user_setting.py
+++ b/outlook/indico_outlook/migrations/20241117_1113_da9deaa182a4_update_user_setting.py
@@ -1,0 +1,55 @@
+"""Update user setting
+
+Revision ID: da9deaa182a4
+Revises: 6093a83228a7
+Create Date: 2024-11-17 11:13:13.705549
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'da9deaa182a4'
+down_revision = '6093a83228a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Rename status_overrides to overrides
+    op.execute('''
+        UPDATE users.settings
+        SET name = 'overrides'
+        WHERE module = 'plugin_outlook' AND name = 'status_overrides'
+    ''')
+    # Add the default settings
+    op.execute('''
+        UPDATE users.settings
+        SET value = (
+            SELECT jsonb_agg(
+                elem || '{"reminder": true, "reminder_minutes": 15}'
+            )
+            FROM jsonb_array_elements(value) AS elem
+        )
+        WHERE module = 'plugin_outlook' AND name = 'overrides'
+    ''')
+
+
+def downgrade():
+    # Remove the default settings
+    op.execute('''
+        UPDATE users.settings
+        SET value = (
+            SELECT jsonb_agg(
+                elem - 'reminder' - 'reminder_minutes'
+            )
+            FROM jsonb_array_elements(value) AS elem
+        )
+        WHERE module = 'plugin_outlook' AND name = 'overrides'
+    ''')
+    # Rename the field back to status_overrides
+    op.execute('''
+        UPDATE users.settings
+        SET name = 'status_overrides'
+        WHERE module = 'plugin_outlook' AND name = 'overrides'
+    ''')

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -80,7 +80,8 @@ class OutlookUserPreferences(ExtraUserPreferences):
                 {'id': 'id', 'caption': _('Category ID'), 'required': True, 'type': 'number', 'step': 1, 'coerce': int},
                 {'id': 'status', 'caption': _('Status'), 'required': False, 'type': 'select'},
                 {'id': 'reminder', 'caption': _('Reminder'), 'required': False, 'type': 'checkbox'},
-                {'id': 'reminder_minutes', 'caption': _('Reminder time'), 'required': False, 'type': 'number', 'step': 1, 'coerce': int},
+                {'id': 'reminder_minutes', 'caption': _('Reminder time'), 'required': False,
+                    'type': 'number', 'step': 1, 'coerce': int},
             ],
             choices={
                 'type': {'category': _('Category'), 'category_tree': _('Category & Subcategories')},
@@ -98,7 +99,8 @@ class OutlookUserPreferences(ExtraUserPreferences):
             'outlook_active': OutlookPlugin.user_settings.get(self.user, 'enabled'),
             'outlook_status': OutlookPlugin.user_settings.get(self.user, 'status', default_status),
             'outlook_reminder': OutlookPlugin.user_settings.get(self.user, 'reminder', default_reminder),
-            'outlook_reminder_minutes': OutlookPlugin.user_settings.get(self.user, 'reminder_minutes', default_reminder_minutes),
+            'outlook_reminder_minutes': OutlookPlugin.user_settings.get(self.user,
+                                                                        'reminder_minutes', default_reminder_minutes),
             'outlook_overrides': OutlookPlugin.user_settings.get(self.user, 'overrides', []),
         }
 

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -59,36 +59,51 @@ class SettingsForm(IndicoForm):
 
 class OutlookUserPreferences(ExtraUserPreferences):
     fields = {
-        'outlook_active': BooleanField(_('Sync with Outlook'), widget=SwitchWidget(),
-                                       description=_('Add Indico events in which I participate to my Outlook '
-                                                     'calendar')),
-        'outlook_status': SelectField(_('Outlook entry status'), [HiddenUnless('extra_outlook_active',
-                                                                               preserve_data=True)],
-                                      choices=_status_choices,
-                                      description=_('The status for Outlook Calendar entries')),
-        'outlook_reminder': BooleanField(_('Reminder'), [HiddenUnless('extra_outlook_active',
-                                                preserve_data=True)],
-                                    description=_('Enable calendar reminder')),
-        'outlook_reminder_minutes': IntegerField(_('Reminder time'), [HiddenUnless('extra_outlook_active',
-                                                preserve_data=True), NumberRange(min=0)],
-                                    description=_('Remind users X minutes before the event')),
+        'outlook_active': BooleanField(
+            _('Sync with Outlook'),
+            widget=SwitchWidget(),
+            description=_('Add Indico events in which I participate to my Outlook calendar'),
+        ),
+        'outlook_status': SelectField(
+            _('Outlook entry status'),
+            [HiddenUnless('extra_outlook_active', preserve_data=True)],
+            choices=_status_choices,
+            description=_('The status for Outlook Calendar entries'),
+        ),
+        'outlook_reminder': BooleanField(
+            _('Outlook reminders'),
+            [HiddenUnless('extra_outlook_active', preserve_data=True)],
+            widget=SwitchWidget(),
+            description=_('Enable reminder for Outlook Calendar entries'),
+        ),
+        'outlook_reminder_minutes': IntegerField(
+            _('Outlook reminder time'),
+            [HiddenUnless('extra_outlook_active', preserve_data=True), NumberRange(min=0)],
+            description=_('Remind X minutes before the event'),
+        ),
         'outlook_overrides': MultipleItemsField(
-            _('Outlook entry overrides'),
+            _('Outlook overrides'),
             [HiddenUnless('extra_outlook_active', preserve_data=True)],
             fields=[
                 {'id': 'type', 'caption': _('Type'), 'required': True, 'type': 'select'},
                 {'id': 'id', 'caption': _('Category ID'), 'required': True, 'type': 'number', 'step': 1, 'coerce': int},
                 {'id': 'status', 'caption': _('Status'), 'required': True, 'type': 'select'},
                 {'id': 'reminder', 'caption': _('Reminder'), 'required': True, 'type': 'checkbox'},
-                {'id': 'reminder_minutes', 'caption': _('Reminder time'), 'required': True,
-                    'type': 'number', 'step': 1, 'coerce': int},
+                {
+                    'id': 'reminder_minutes',
+                    'caption': _('Reminder time'),
+                    'required': True,
+                    'type': 'number',
+                    'step': 1,
+                    'coerce': int,
+                },
             ],
             choices={
                 'type': {'category': _('Category'), 'category_tree': _('Category & Subcategories')},
                 'status': dict(_status_choices),
             },
             description=_('You can override the calendar entry configuration for specific categories.'),
-        )
+        ),
     }
 
     def load(self):

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -78,9 +78,9 @@ class OutlookUserPreferences(ExtraUserPreferences):
             fields=[
                 {'id': 'type', 'caption': _('Type'), 'required': True, 'type': 'select'},
                 {'id': 'id', 'caption': _('Category ID'), 'required': True, 'type': 'number', 'step': 1, 'coerce': int},
-                {'id': 'status', 'caption': _('Status'), 'required': False, 'type': 'select'},
-                {'id': 'reminder', 'caption': _('Reminder'), 'required': False, 'type': 'checkbox'},
-                {'id': 'reminder_minutes', 'caption': _('Reminder time'), 'required': False,
+                {'id': 'status', 'caption': _('Status'), 'required': True, 'type': 'select'},
+                {'id': 'reminder', 'caption': _('Reminder'), 'required': True, 'type': 'checkbox'},
+                {'id': 'reminder_minutes', 'caption': _('Reminder time'), 'required': True,
                     'type': 'number', 'step': 1, 'coerce': int},
             ],
             choices={


### PR DESCRIPTION
Let the user configure if they want reminders or not, and how far in advance. Also let them define those as overrides per category.

@ThiefMaster note that this still needs some work, and I'm hoping you can give me a hint. My idea for the overrides is to have a single field where the user could define the status, reminder and/or reminder_time per category. However, I can't figure out how to get MultipleItemsField to have a validator so that _at least one of_ those values is filled in. Also, if the user doesn't specify a value for a particular variable, it should be passed as a None, otherwise  `_get_status`/`_get_reminder` can't tell the difference between an actual override and a blank. Perhaps this is too complicated for `MultipleItemsField` as it's currently implemented?