### PR TITLE
Add favorites to Outlook calendar

### DIFF
--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -194,6 +194,11 @@ class OutlookPlugin(IndicoPlugin):
         # Users that have marked the event as favorite too
         users_to_update |= event.favorite_of
 
+        # Now look for users that have marked as favorite that event's category (or any of its parents)
+        for category in event.category.chain_query.all():
+            for user in category.favorite_of:
+                users_to_update.add(user)
+
         for user in users_to_update:
             self.logger.info('Event data change: updating %s in %r', user, event)
             self._record_change(event, user, OutlookAction.update)

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -137,6 +137,8 @@ class OutlookPlugin(IndicoPlugin):
         self.connect(signals.event.deleted, self.event_deleted)
         self.connect(signals.core.after_process, self._apply_changes)
         self.connect(signals.users.merged, self._merge_users)
+        self.connect(signals.users.favorite_event_added, self.favorite_event_added)
+        self.connect(signals.users.favorite_event_removed, self.favorite_event_removed)
 
     def _extend_indico_cli(self, sender, **kwargs):
         @cli_command()
@@ -147,6 +149,14 @@ class OutlookPlugin(IndicoPlugin):
 
     def extend_user_preferences(self, user, **kwargs):
         return OutlookUserPreferences
+
+    def favorite_event_added(self, user, event, **kwargs):
+        self._record_change(event, user, OutlookAction.add)
+        self.logger.info('Favorite event added: updating %s in %r', user, event)
+
+    def favorite_event_removed(self, user, event, **kwargs):
+        self._record_change(event, user, OutlookAction.remove)
+        self.logger.info('Favorite event removed: updating %s in %r', user, event)
 
     def event_registration_state_changed(self, registration, **kwargs):
         if not registration.user:
@@ -178,7 +188,13 @@ class OutlookPlugin(IndicoPlugin):
     def event_updated(self, event, changes, **kwargs):
         if not changes.keys() & {'title', 'description', 'location_data'}:
             return
-        for user in get_participating_users(event):
+
+        # Registered users need to be informed about changes
+        users_to_update = set(get_participating_users(event))
+        # Users that have marked the event as favorite too
+        users_to_update |= event.favorite_of
+
+        for user in users_to_update:
             self.logger.info('Event data change: updating %s in %r', user, event)
             self._record_change(event, user, OutlookAction.update)
 
@@ -198,6 +214,12 @@ class OutlookPlugin(IndicoPlugin):
             return
         if 'outlook_changes' not in g:
             g.outlook_changes = []
+
+        if action == OutlookAction.remove:
+            # Only remove an event if the user *really* shouldn't have it in their calendar
+            if user in get_participating_users(event) or user in event.favorite_of:
+                return
+
         g.outlook_changes.append((event, user, action))
 
     def _apply_changes(self, sender, **kwargs):

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -62,6 +62,9 @@ class OutlookUserPreferences(ExtraUserPreferences):
         'outlook_active': BooleanField(_('Sync with Outlook'), widget=SwitchWidget(),
                                        description=_('Add Indico events in which I participate to my Outlook '
                                                      'calendar')),
+        'outlook_favorites': BooleanField(_('Sync favorites with Outlook'), [HiddenUnless('extra_outlook_active',
+                                    preserve_data=True)], widget=SwitchWidget(),
+                                    description=_('Add events/categories I mark as favorite to my Outlook calendar')),
         'outlook_status': SelectField(_('Outlook entry status'), [HiddenUnless('extra_outlook_active',
                                                                                preserve_data=True)],
                                       choices=_status_choices,
@@ -86,6 +89,7 @@ class OutlookUserPreferences(ExtraUserPreferences):
         default_status = OutlookPlugin.settings.get('status')
         return {
             'outlook_active': OutlookPlugin.user_settings.get(self.user, 'enabled'),
+            'outlook_favorites': OutlookPlugin.user_settings.get(self.user, 'favorites'),
             'outlook_status': OutlookPlugin.user_settings.get(self.user, 'status', default_status),
             'outlook_status_overrides': OutlookPlugin.user_settings.get(self.user, 'status_overrides', [])
         }
@@ -93,6 +97,7 @@ class OutlookUserPreferences(ExtraUserPreferences):
     def save(self, data):
         OutlookPlugin.user_settings.set_multi(self.user, {
             'enabled': data['outlook_active'],
+            'favorites': data['outlook_favorites'],
             'status': data['outlook_status'],
             'status_overrides': data['outlook_status_overrides']
         })
@@ -121,6 +126,7 @@ class OutlookPlugin(IndicoPlugin):
     }
     default_user_settings = {
         'enabled': True,  # XXX: if the default value ever changes, adapt `get_participating_users`!
+        'favorites': True,
         'status': None,
         'status_overrides': [],
     }
@@ -151,10 +157,14 @@ class OutlookPlugin(IndicoPlugin):
         return OutlookUserPreferences
 
     def favorite_event_added(self, user, event, **kwargs):
+        if not OutlookPlugin.user_settings.get(user, 'favorites', OutlookPlugin.default_user_settings['favorites']):
+            return
         self._record_change(event, user, OutlookAction.add)
         self.logger.info('Favorite event added: updating %s in %r', user, event)
 
     def favorite_event_removed(self, user, event, **kwargs):
+        if not OutlookPlugin.user_settings.get(user, 'favorites', OutlookPlugin.default_user_settings['favorites']):
+            return
         self._record_change(event, user, OutlookAction.remove)
         self.logger.info('Favorite event removed: updating %s in %r', user, event)
 


### PR DESCRIPTION
Add favorite events and categories to Outlook calendar.

For favorited categories, only new/updated events are added to the calendar because Indico is missing the signals `signals.users.favorite_category_added` and `signals.users.favorite_category_removed`.