### PR TITLE
Outlook: Support adding favorite categories

### DIFF
--- a/outlook/indico_outlook/calendar.py
+++ b/outlook/indico_outlook/calendar.py
@@ -5,22 +5,28 @@
 # them and/or modify them under the terms of the MIT License; see
 # the LICENSE file for more details.
 
+from collections import defaultdict
+from itertools import islice
 from pprint import pformat
 
 import requests
 from markupsafe import Markup
 from requests.exceptions import RequestException, Timeout
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, subqueryload
 from werkzeug.datastructures import MultiDict
 
 from indico.core import signals
 from indico.core.db import db
+from indico.modules.events import Event
+from indico.modules.events.forms import EventLabel
+from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
 from indico.util.string import strip_control_chars
 
 from indico_outlook.models.entry import OutlookCalendarEntry
 from indico_outlook.models.queue import OutlookAction, OutlookQueueEntry
-from indico_outlook.util import check_config, is_event_excluded
+from indico_outlook.util import (check_config, get_users_to_add, is_event_excluded, is_user_cat_favorite,
+                                 is_user_favorite, is_user_registered)
 
 
 def update_calendar():
@@ -32,9 +38,145 @@ def update_calendar():
         return
 
     settings = OutlookPlugin.settings.get_all()
+    logger = OutlookPlugin.logger
+    ignore = _process_favorite_categories(settings, logger)
+    _process_events(ignore, settings, logger)
+
+
+def _delete_queue_entries(ids):
+    if not ids:
+        return
+    OutlookQueueEntry.query.filter(OutlookQueueEntry.id.in_(ids)).delete(synchronize_session=False)
+    db.session.commit()
+
+
+def _process_favorite_categories(settings, logger):
+    # process the category queue
+    query = (OutlookQueueEntry.query
+             .options(joinedload(OutlookQueueEntry.category))
+             .order_by(OutlookQueueEntry.user_id, OutlookQueueEntry.id)
+             .filter(OutlookQueueEntry.category_id.isnot(None)))
+    by_category = {}
+    delete_ids = set()
+    for entry in query:
+        if (
+            (existing := by_category.get(entry.category))
+            and existing.action == OutlookAction.add
+            and entry.action == OutlookAction.remove
+        ):
+            # add + remove --> ignore both and do nothing; this was someone adding and immediately
+            # removing a favorite category.
+            # we don't do the same for remove + add, because someone may use this after turning on
+            # this feature for favorite categories and toggling the favorite state of a category to
+            # force new events in there to be added
+            logger.debug('Ignoring add+remove for category %r / user %r', entry.category, entry.user)
+            delete_ids.add(existing.id)
+            delete_ids.add(entry.id)
+            del by_category[entry.category]
+            continue
+        by_category[entry.category] = entry
+
+    if delete_ids:
+        _delete_queue_entries(delete_ids)
+        delete_ids.clear()
+
+    by_user = defaultdict(set)
+    for entry in by_category.values():
+        by_user[entry.user].add(entry)
+
+    ignore = set()
+    for user, entries in by_user.items():
+        delete_cat_entries = {x for x in entries if x.action == OutlookAction.remove}
+        add_cat_entries = {(x.category, x) for x in entries if x.action == OutlookAction.add}
+        del entries
+
+        if delete_cat_entries:
+            logger.debug('Processing category favorite removals for %r', user)
+            # deletion is an easy case, we can simply get all future events within the deleted
+            # category subtrees where the user has a calendar entry, unless it's also visible
+            # in another favorite category...
+            events = Event.query.filter(
+                Event.end_dt > now_utc(),
+                ~Event.is_deleted,
+                Event.category_chain_overlaps({x.category_id for x in delete_cat_entries}),
+                Event.outlook_calendar_entries.any(OutlookCalendarEntry.user == user),
+            ).all()
+            success = True
+            for event in events:
+                if is_user_registered(event, user):
+                    logger.debug('Ignoring remove for %r; user is registered', event)
+                    continue
+                if is_user_favorite(event, user):
+                    logger.debug('Ignoring remove for %r; event is favorite', event)
+                    continue
+                if is_user_cat_favorite(event, user):
+                    logger.debug('Ignoring remove for %r; event is cat favorite', event)
+                    continue
+                logger.info('Removing event %r', event)
+                if not _update_calendar_entry(event, user, OutlookAction.remove, settings):
+                    success = False
+                else:
+                    ignore.add((event, user))
+
+            if success:
+                _delete_queue_entries({x.id for x in delete_cat_entries})
+
+        for cat, entry in add_cat_entries:
+            logger.info('Processing category favorite addition for %r: %r', user, cat)
+            query = (
+                Event.query.filter(
+                    Event.end_dt > now_utc(),
+                    Event.duration <= settings['max_event_duration'],
+                    ~Event.is_deleted,
+                    Event.is_visible_in(cat.id),
+                    ~Event.label.has(EventLabel.is_event_not_happening),
+                    ~Event.outlook_calendar_entries.any(OutlookCalendarEntry.user == user),
+                )
+                .options(subqueryload('acl_entries'))
+                .order_by(Event.start_dt, Event.id)
+            )
+            total_limit = settings['max_category_events']
+            limit = settings['max_accessible_category_events']
+            # bail out early if it's a ridiculously big category (e.g. root category)
+            if (count := query.count()) > total_limit:
+                logger.info('Ignoring favorite category %r: too many future events (%d > %d)', cat, count,
+                            total_limit)
+                delete_ids.add(entry.id)
+                continue
+            # get the events which the user can actually access
+            events = list(islice((e for e in query if e.can_access(user, allow_admin=False)), limit + 1))
+            if len(events) > limit:
+                logger.info('Ignoring favorite category %r: too many accessible future events (%d > %d)', cat,
+                            count, limit)
+                delete_ids.add(entry.id)
+                continue
+            logger.info('Adding %d events visible in favorite category %r', count, cat)
+            success = True
+            for event in events:
+                logger.info('Adding event %r', event)
+                if not _update_calendar_entry(event, user, OutlookAction.add, settings):
+                    success = False
+                else:
+                    ignore.add((event, user))
+            if success:
+                delete_ids.add(entry.id)
+                _delete_queue_entries(delete_ids)
+                delete_ids.clear()
+
+        # skipped large category entries may not have been deleted yet
+        if delete_ids:
+            _delete_queue_entries(delete_ids)
+            delete_ids.clear()
+
+    return ignore
+
+
+def _process_events(ignore, settings, logger):
+    # process the event queue, including any changes we may have created due to category changes
     query = (OutlookQueueEntry.query
              .options(joinedload(OutlookQueueEntry.event))
-             .order_by(OutlookQueueEntry.user_id, OutlookQueueEntry.id))
+             .order_by(OutlookQueueEntry.id)
+             .filter(OutlookQueueEntry.event_id.isnot(None)))
     entries = MultiDict(((entry.user_id, entry.event_id), entry) for entry in query)
     delete_ids = set()
     try:
@@ -50,6 +192,9 @@ def update_calendar():
                 seen.add(entry.action)
                 if is_event_excluded(entry.event):
                     continue
+                if (entry.event, entry.user) in ignore:
+                    logger.debug('Ignoring %s due to favorite category change: %r', entry.action.name, entry)
+                    continue
                 todo.append(entry)
             # execute those entries in the original order, so cases like
             # "add, update, delete, add, update, update" are correctly
@@ -57,14 +202,30 @@ def update_calendar():
             # someone was removed from the registration and added back
             # without processing entries in between
             for entry in reversed(todo):
-                if not _update_calendar_entry(entry, settings):
+                logger.info('Processing %s', entry)
+                if entry.user and not _update_calendar_entry(entry.event, entry.user, entry.action, settings):
+                    entry_ids.remove(entry.id)
+                elif not entry.user and not _update_bulk(entry.event, entry.action, settings):
                     entry_ids.remove(entry.id)
             # record all ids which didn't fail for deletion
             delete_ids |= entry_ids
     finally:
-        if delete_ids:
-            OutlookQueueEntry.query.filter(OutlookQueueEntry.id.in_(delete_ids)).delete(synchronize_session=False)
-        db.session.commit()
+        _delete_queue_entries(delete_ids)
+
+
+def _update_bulk(event, action, settings):
+    if action in {OutlookAction.update, OutlookAction.remove}:
+        success = True
+        for cal_entry in event.outlook_calendar_entries:
+            if not _update_calendar_entry(event, cal_entry.user, action, settings):
+                success = False
+        return success
+    elif action == OutlookAction.add:
+        success = True
+        for user in get_users_to_add(event):
+            if not _update_calendar_entry(event, user, action, settings):
+                success = False
+        return success
 
 
 def _get_status(user, event, settings):
@@ -103,41 +264,34 @@ def _make_calendar_id(event, user, settings):
     return f'{settings["id_prefix"]}{user.id}_{event.id}'
 
 
-def _update_calendar_entry(entry: OutlookQueueEntry, settings):
-    """Executes a single calendar update
+def _update_calendar_entry(event, user, action, settings) -> bool:
+    """Execute a single calendar update.
 
-    :param entry: a :class:`OutlookQueueEntry`
-    :param settings: the plugin settings
+    :return: `True` if the related queue entry should be removed.
     """
     from indico_outlook.plugin import OutlookPlugin
     logger = OutlookPlugin.logger
 
-    logger.info('Processing %s', entry)
-    user = entry.user
-    if user is None:
-        logger.debug('Ignoring %s for deleted user %s', entry.action.name, entry.user_id)
-        return True
-    elif not OutlookPlugin.user_settings.get(user, 'enabled'):
+    if not OutlookPlugin.user_settings.get(user, 'enabled'):
         logger.debug('User %s has disabled calendar entries', user)
         return True
 
-    if existing := OutlookCalendarEntry.get(entry.event, user):
+    if existing := OutlookCalendarEntry.get(event, user):
         logger.debug('Found existing calendar entry in DB: %s', existing.calendar_entry_id)
-    elif entry.action == OutlookAction.update:
-        logger.info('No calendar entry found in DB for event=%s/user=%s during update', entry.event.id, user.id)
-    elif entry.action == OutlookAction.remove:
-        logger.debug('No calendar entry found in DB for event=%s/user=%s, ignoring remove', entry.event.id, user.id)
+    elif action == OutlookAction.update:
+        logger.info('No calendar entry found in DB for event=%s/user=%s during update', event.id, user.id)
+    elif action == OutlookAction.remove:
+        logger.debug('No calendar entry found in DB for event=%s/user=%s, ignoring remove', event.id, user.id)
         return True
 
     # Use common format for event calendar ID if the event was created after the cutoff event
-    unique_id = existing.calendar_entry_id if existing else _make_calendar_id(entry.event, user, settings)
+    unique_id = existing.calendar_entry_id if existing else _make_calendar_id(event, user, settings)
     path = f'/api/v1/users/{user.email}/events/{unique_id}'
     url = settings['service_url'].rstrip('/') + path
-    if entry.action in {OutlookAction.add, OutlookAction.update}:
+    if action in {OutlookAction.add, OutlookAction.update}:
         method = 'PUT'
-        event = entry.event
         if event.is_deleted:
-            logger.debug('Ignoring %s for deleted event %s', entry.action.name, entry.event_id)
+            logger.debug('Ignoring %s for deleted event %s', action.name, event.id)
             return True
         reminder, reminder_minutes = _get_reminder(user, event, settings)
         location = (f'{event.room_name} ({event.venue_name})'
@@ -177,11 +331,11 @@ def _update_calendar_entry(entry: OutlookQueueEntry, settings):
             data.update(update)
         # the API expects the field to be named 'body', contrarily to our usage
         data['body'] = data.pop('description')
-    elif entry.action == OutlookAction.remove:
+    elif action == OutlookAction.remove:
         method = 'DELETE'
         data = None
     else:
-        raise ValueError(f'Unexpected action: {entry.action}')
+        raise ValueError(f'Unexpected action: {action}')
 
     if settings['debug']:
         logger.debug('Calendar update request:\nURL: %s\nData: %s', url, pformat(data))
@@ -199,20 +353,20 @@ def _update_calendar_entry(entry: OutlookQueueEntry, settings):
         return False
     else:
         logger.info('Request to %s %s finished with status %r and body %r', method, path, res.status_code, res.text)
-        if res.ok and not existing and entry.action in {OutlookAction.add, OutlookAction.update}:
+        if res.ok and not existing and action in {OutlookAction.add, OutlookAction.update}:
             # successfully added or updated w/ no reference to existing entry
             OutlookCalendarEntry.create(event, user, unique_id)
             logger.debug('Recorded calendar entry in DB')
-            db.session.flush()
-        elif (res.ok or res.status_code == 404) and entry.action == OutlookAction.remove:
+            db.session.commit()
+        elif (res.ok or res.status_code == 404) and action == OutlookAction.remove:
             # successfully removed or nothing to remove
             db.session.delete(existing)
-            db.session.flush()
+            db.session.commit()
             logger.debug('Removed calendar entry from DB')
-        elif res.status_code == 404 and entry.action == OutlookAction.update and existing:
+        elif res.status_code == 404 and action == OutlookAction.update and existing:
             # tried to update but nothing to update
             db.session.delete(existing)
-            db.session.flush()
+            db.session.commit()
             logger.debug('Removed calendar entry from DB')
         # 404 is "already deleted" or "user has no mailbox" - both cases we consider a success
         if res.ok or res.status_code == 404:

--- a/outlook/indico_outlook/migrations/20250804_1641_189fb3e6e489_support_category_queue_entries.py
+++ b/outlook/indico_outlook/migrations/20250804_1641_189fb3e6e489_support_category_queue_entries.py
@@ -1,0 +1,36 @@
+"""Support category queue entries
+
+Revision ID: 189fb3e6e489
+Revises: 532798ae4e02
+Create Date: 2025-08-04 16:41:11.447463
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '189fb3e6e489'
+down_revision = '532798ae4e02'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('queue', sa.Column('category_id', sa.Integer(), nullable=True), schema='plugin_outlook')
+    op.alter_column('queue', 'event_id', nullable=True, schema='plugin_outlook')
+    op.create_index(None, 'queue', ['category_id'], unique=False, schema='plugin_outlook')
+    op.create_foreign_key(None, 'queue', 'categories', ['category_id'], ['id'],
+                          source_schema='plugin_outlook', referent_schema='categories')
+    op.create_check_constraint('no_category_updates', 'queue', '(action != 2) OR (category_id IS NULL)',
+                               schema='plugin_outlook')
+    op.create_check_constraint('event_xor_category', 'queue', '(event_id IS NULL) != (category_id IS NULL)',
+                               schema='plugin_outlook')
+
+
+def downgrade():
+    op.execute('DELETE FROM plugin_outlook.queue WHERE event_id IS NULL')
+    op.drop_constraint('ck_queue_no_category_updates', 'queue', schema='plugin_outlook')
+    op.drop_constraint('ck_queue_event_xor_category', 'queue', schema='plugin_outlook')
+    op.alter_column('queue', 'event_id', nullable=False, schema='plugin_outlook')
+    op.drop_column('queue', 'category_id', schema='plugin_outlook')

--- a/outlook/indico_outlook/migrations/20250806_1748_f166c1593d5e_allow_queue_entries_without_user.py
+++ b/outlook/indico_outlook/migrations/20250806_1748_f166c1593d5e_allow_queue_entries_without_user.py
@@ -1,0 +1,24 @@
+"""Allow queue entries without user
+
+Revision ID: f166c1593d5e
+Revises: 189fb3e6e489
+Create Date: 2025-08-06 17:48:08.619145
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'f166c1593d5e'
+down_revision = '189fb3e6e489'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('queue', 'user_id', nullable=True, schema='plugin_outlook')
+
+
+def downgrade():
+    op.execute('DELETE FROM plugin_outlook.queue WHERE user_id IS NULL')
+    op.alter_column('queue', 'user_id', nullable=False, schema='plugin_outlook')

--- a/outlook/indico_outlook/util.py
+++ b/outlook/indico_outlook/util.py
@@ -7,11 +7,15 @@
 
 from sqlalchemy.orm import joinedload
 
+from indico.cli.event import User
 from indico.core.db import db
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.users import UserSetting
+from indico.modules.users.models.favorites import favorite_event_table
 from indico.util.date_time import now_utc
+
+from indico_outlook.models.entry import OutlookCalendarEntry
 
 
 def check_config():
@@ -36,30 +40,117 @@ def is_event_excluded(event, logger=None):
     return False
 
 
+def _query_registered_users(event):
+    return (Registration.query
+            .filter(Registration.is_active,
+                    ~RegistrationForm.is_deleted,
+                    Registration.user_id.isnot(None),
+                    RegistrationForm.event_id == event.id)
+            .filter(~UserSetting.query
+                    .filter(UserSetting.user_id == Registration.user_id,
+                            UserSetting.module == 'plugin_outlook',
+                            UserSetting.name == 'enabled',
+                            UserSetting.value == db.func.to_jsonb(False))
+                    .correlate(Registration)
+                    .exists())
+            .filter(~UserSetting.query
+                    .filter(UserSetting.user_id == Registration.user_id,
+                            UserSetting.module == 'plugin_outlook',
+                            UserSetting.name == 'registered',
+                            UserSetting.value == db.func.to_jsonb(False))
+                    .correlate(Registration)
+                    .exists())
+            .join(Registration.registration_form)
+            .options(joinedload(Registration.user)))
+
+
+def is_user_registered(event, user):
+    """Check if the user is registered in the event and wants it in their calendar."""
+    return _query_registered_users(event).filter(Registration.user == user).has_rows()
+
+
 def get_registered_users(event):
     """Return participating users of an event who did not disable calendar updates."""
-    registrations = (Registration.query
-                     .filter(Registration.is_active,
-                             ~RegistrationForm.is_deleted,
-                             Registration.user_id.isnot(None),
-                             RegistrationForm.event_id == event.id)
-                     .filter(~UserSetting.query
-                             .filter(UserSetting.user_id == Registration.user_id,
-                                     UserSetting.module == 'plugin_outlook',
-                                     UserSetting.name == 'enabled',
-                                     UserSetting.value == db.func.to_jsonb(False))
-                             .correlate(Registration)
-                             .exists())
-                     .filter(~UserSetting.query
-                             .filter(UserSetting.user_id == Registration.user_id,
-                                     UserSetting.module == 'plugin_outlook',
-                                     UserSetting.name == 'registered',
-                                     UserSetting.value == db.func.to_jsonb(False))
-                             .correlate(Registration)
-                             .exists())
-                     .join(Registration.registration_form)
-                     .options(joinedload(Registration.user)))
-    return {reg.user for reg in registrations}
+    return {reg.user for reg in _query_registered_users(event)}
+
+
+def _query_favorite_users(event):
+    return (User.query
+            .join(favorite_event_table, favorite_event_table.c.user_id == User.id)
+            .filter(favorite_event_table.c.target_id == event.id)
+            .filter(~UserSetting.query
+                    .filter(UserSetting.user_id == User.id,
+                            UserSetting.module == 'plugin_outlook',
+                            UserSetting.name == 'enabled',
+                            UserSetting.value == db.func.to_jsonb(False))
+                    .correlate(User)
+                    .exists())
+            .filter(~UserSetting.query
+                    .filter(UserSetting.user_id == User.id,
+                            UserSetting.module == 'plugin_outlook',
+                            UserSetting.name == 'favorite_events',
+                            UserSetting.value == db.func.to_jsonb(False))
+                    .correlate(User)
+                    .exists()))
+
+
+def is_user_favorite(event, user):
+    """Check if the user favorited the event and wants it in their calendar."""
+    return _query_favorite_users(event).filter(User.id == user.id).has_rows()
+
+
+def get_favorite_users(event):
+    """Return users who favorited an event and did not disable calendar updates."""
+    return set(_query_favorite_users(event))
+
+
+def _iter_visible_categories(event):
+    if event.visibility == 0:
+        return
+    horizon = event.category.real_visibility_horizon
+    for i, cat in enumerate(reversed(event.category.chain_query.all()), 1):
+        yield cat
+        # Stop if we reach the visibility horizon of the event
+        if i == event.visibility:
+            return
+        # Stop if we reach the visibility horizon of the category
+        if cat == horizon:
+            return
+
+
+def is_user_cat_favorite(event, user):
+    """Check if the event is in a favorite category of the user and tracks favorite categories."""
+    from indico_outlook.plugin import OutlookPlugin
+    if not OutlookPlugin.user_settings.get(user, 'favorite_categories'):
+        return False
+    if event.is_unlisted:
+        return False
+    return any(cat in user.favorite_categories for cat in _iter_visible_categories(event))
+
+
+def get_cat_favorite_users(event):
+    """Return users who have the event in a favorite category and did not disable calendar updates."""
+    from indico_outlook.plugin import OutlookPlugin
+    plugin = OutlookPlugin.instance
+    if event.is_unlisted:
+        return set()
+    return {
+        user
+        for cat in _iter_visible_categories(event)
+        for user in cat.favorite_of
+        if plugin._user_tracks_favorite_categories(user) and event.can_access(user, allow_admin=False)
+    }
+
+
+def get_users_to_add(event):
+    """Get users who should have the event in their calendar but currently don't have it."""
+    users_to_add = set()
+    users_to_add |= get_registered_users(event)
+    users_to_add |= get_favorite_users(event)
+    users_to_add |= get_cat_favorite_users(event)
+    # Skip users who already have calendar entries
+    existing_users = {x.user for x in event.outlook_calendar_entries.options(joinedload(OutlookCalendarEntry.user))}
+    return users_to_add - existing_users
 
 
 def latest_actions_only(items):


### PR DESCRIPTION
This is the last, and trickiest, remaining piece from #184.

I also did quite a bit of refactoring here to move logic from the signal handlers into the background task, in particular for anything related to adding/removing an event for everyone involved, since it's pointless to spam the queue with individual entries there, when we can just get a fresh list of relevant people directly from the database.

closes #184