### PR TITLE
CERNAccess: Limit license plate to 24 chars

### DIFF
--- a/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
+++ b/cern_access/indico_cern_access/client/RegistrationIdentityDataForm.jsx
@@ -225,6 +225,7 @@ export default function RegistrationIdentityDataForm({
           as={FinalInput}
           required
           nullIfEmpty
+          maxLength={24}
           validate={val => {
             if (!val) {
               return undefined;

--- a/cern_access/indico_cern_access/schemas.py
+++ b/cern_access/indico_cern_access/schemas.py
@@ -36,7 +36,8 @@ class RequestAccessSchema(mm.Schema):
     accompanying_persons = fields.Dict(keys=fields.String(), values=fields.Nested(AccompanyingPersonAccessSchema),
                                        load_default={}, data_key='cern_access_accompanying_persons')
     by_car = fields.Bool(load_default=False, data_key='cern_access_by_car')
-    license_plate = fields.String(data_key='cern_access_license_plate', load_default=None)
+    license_plate = fields.String(data_key='cern_access_license_plate', validate=validate.Length(max=24),
+                                  load_default=None)
 
     @validates_schema
     def validate_everything(self, data, **kwargs):


### PR DESCRIPTION
When people put longer text, usually "i do not know my license plate yet"
and the likes, it failed when making the request to ADaMS, and it required
is to manually check and fix it since event organizers cannot see nor
modify this data.
