### PR TITLE
Add 'visibility' to monitored keys in event update

### DIFF
--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -310,7 +310,7 @@ class OutlookPlugin(IndicoPlugin):
 
     def event_updated(self, event, changes, **kwargs):
         changes = dict(changes)
-        monitored_keys = {'title', 'description', 'location_data', 'person_links', 'label', 'start_dt', 'end_dt'}
+        monitored_keys = {'title', 'description', 'location_data', 'person_links', 'label', 'start_dt', 'end_dt', 'visibility'}
         if not changes.keys() & monitored_keys:
             return
         if label_change := changes.pop('label', None):

--- a/outlook/indico_outlook/plugin.py
+++ b/outlook/indico_outlook/plugin.py
@@ -310,7 +310,16 @@ class OutlookPlugin(IndicoPlugin):
 
     def event_updated(self, event, changes, **kwargs):
         changes = dict(changes)
-        monitored_keys = {'title', 'description', 'location_data', 'person_links', 'label', 'start_dt', 'end_dt', 'visibility'}
+        monitored_keys = {
+            'title',
+            'description',
+            'location_data',
+            'person_links',
+            'label',
+            'start_dt',
+            'end_dt',
+            'visibility',
+        }
         if not changes.keys() & monitored_keys:
             return
         if label_change := changes.pop('label', None):


### PR DESCRIPTION
Currently, the calendar won't show correctly events where the visibility was changed.